### PR TITLE
Change the names of the instance role and profile

### DIFF
--- a/instance_role.tf
+++ b/instance_role.tf
@@ -16,7 +16,7 @@ data "aws_iam_policy_document" "assume_role_doc" {
 # The S3 certificate access role to be used by the IPA master EC2
 # instance
 resource "aws_iam_role" "ipa" {
-  name               = "ipa_master_instance_role_${terraform.workspace}"
+  name               = "ipa_master_instance_role_${var.hostname}"
   assume_role_policy = data.aws_iam_policy_document.assume_role_doc.json
 }
 
@@ -41,6 +41,6 @@ resource "aws_iam_role_policy" "assume_delegated_role_policy" {
 
 # The instance profile to be used by the IPA master EC2 instance.
 resource "aws_iam_instance_profile" "ipa" {
-  name = "ipa_master_instance_profile_${terraform.workspace}"
+  name = "ipa_master_instance_profile_${var.hostname}"
   role = aws_iam_role.ipa.name
 }


### PR DESCRIPTION
It is possible that there could be more than one master, and in that case the hostname would be unique whereas the workspace may not be.