### PR TITLE
Clean up certificate handling

### DIFF
--- a/cloud-init/setup_freeipa.sh
+++ b/cloud-init/setup_freeipa.sh
@@ -54,8 +54,6 @@ ipa-server-install --realm="${realm}" \
                    --http-pin="${cert_pw}" \
                    --dirsrv-cert-file=/etc/ipa/cert.p12 \
                    --dirsrv-pin="${cert_pw}" \
-                   --ca-cert-file=/etc/ipa/isrgrootx1.pem  \
-                   --ca-cert-file=/etc/ipa/letsencryptauthorityx3.pem \
                    --no-ntp \
                    --no-pkinit \
                    --no_hbac_allow \


### PR DESCRIPTION
* Include the proper intermediate and root certs in the PKCS#12 file, since FreeIPA insists that the ENTIRE certificate chain be present.
* This renders the `--ca-cert-file` options in the FreeIPA install command obsolete, so remove them.
