### PR TITLE
Attach the CloudWatchAgentServerPolicy policy to the instance role

### DIFF
--- a/instance_role.tf
+++ b/instance_role.tf
@@ -39,13 +39,10 @@ resource "aws_iam_role_policy" "assume_delegated_role_policy" {
   policy = "${data.aws_iam_policy_document.assume_delegated_role_policy_doc.json}"
 }
 
-# Grab the AWS caller identity for this provider
-data "aws_caller_identity" "default" {}
-
 # Attach the CloudWatch Agent policy to this role as well
 resource "aws_iam_role_policy_attachment" "cloudwatch_agent_policy_attachment" {
   role       = aws_iam_role.ipa.id
-  policy_arn = "arn:aws:iam::${data.aws_caller_identity.default.account_id}:policy/CloudWatchAgentServerPolicy"
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
 }
 
 # The instance profile to be used by the IPA master EC2 instance.

--- a/instance_role.tf
+++ b/instance_role.tf
@@ -39,6 +39,15 @@ resource "aws_iam_role_policy" "assume_delegated_role_policy" {
   policy = "${data.aws_iam_policy_document.assume_delegated_role_policy_doc.json}"
 }
 
+# Grab the AWS caller identity for this provider
+data "aws_caller_identity" "default" {}
+
+# Attach the CloudWatch Agent policy to this role as well
+resource "aws_iam_role_policy_attachment" "cloudwatch_agent_policy_attachment" {
+  role       = aws_iam_role.ipa.id
+  policy_arn = "arn:aws:iam::${data.aws_caller_identity.default.account_id}:policy/CloudWatchAgentServerPolicy"
+}
+
 # The instance profile to be used by the IPA master EC2 instance.
 resource "aws_iam_instance_profile" "ipa" {
   name = "ipa_master_instance_profile_${var.hostname}"


### PR DESCRIPTION
This AWS-provided policy allows the instance to send logs and metrics to CloudWatch.