### PR TITLE
Add security group for FreeIPA clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ module "ipa_master" {
 
 | Name | Description |
 |------|-------------|
+| client_security_group_id | The ID of the IPA client security group |
 | id | The EC2 instance ID corresponding to the IPA master |
 | server_security_group_id | The ID of the IPA server security group |
 

--- a/client_security_group.tf
+++ b/client_security_group.tf
@@ -1,0 +1,31 @@
+# Security group for IPA clients
+resource "aws_security_group" "ipa_clients" {
+  vpc_id = data.aws_subnet.the_subnet.vpc_id
+
+  description = "Security group for IPA clients"
+  tags        = var.tags
+}
+
+# TCP egress rules for IPA
+resource "aws_security_group_rule" "ipa_client_tcp_egress" {
+  count = length(local.ipa_tcp_ports)
+
+  security_group_id        = aws_security_group.ipa_clients.id
+  type                     = "egress"
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.ipa_servers.id
+  from_port                = local.ipa_tcp_ports[count.index]
+  to_port                  = local.ipa_tcp_ports[count.index]
+}
+
+# UDP egress rules for IPA
+resource "aws_security_group_rule" "ipa_client_udp_egress" {
+  count = length(local.ipa_udp_ports)
+
+  security_group_id        = aws_security_group.ipa_clients.id
+  type                     = "egress"
+  protocol                 = "udp"
+  source_security_group_id = aws_security_group.ipa_servers.id
+  from_port                = local.ipa_udp_ports[count.index]
+  to_port                  = local.ipa_udp_ports[count.index]
+}

--- a/examples/basic_usage/README.md
+++ b/examples/basic_usage/README.md
@@ -12,5 +12,6 @@ Note that this example may create resources which cost money. Run
 
 | Name | Description |
 |------|-------------|
+| ipa_client_security_group_id | The ID corresponding to the IPA client security group |
 | ipa_server_security_group_id | The ID corresponding to the IPA server security group |
 | master_id | The EC2 instance ID corresponding to the IPA master |

--- a/examples/basic_usage/outputs.tf
+++ b/examples/basic_usage/outputs.tf
@@ -1,3 +1,8 @@
+output "ipa_client_security_group_id" {
+  value       = module.ipa_master.client_security_group_id
+  description = "The ID corresponding to the IPA client security group"
+}
+
 output "ipa_server_security_group_id" {
   value       = module.ipa_master.server_security_group_id
   description = "The ID corresponding to the IPA server security group"

--- a/examples/basic_usage/terraform.tf
+++ b/examples/basic_usage/terraform.tf
@@ -1,0 +1,11 @@
+terraform {
+  backend "s3" {
+    encrypt        = true
+    bucket         = "cisa-cool-terraform-state"
+    dynamodb_table = "terraform-state-lock"
+    region         = "us-east-1"
+    profile        = "cool-user"
+    role_arn       = "arn:aws:iam::608004238745:role/TerraformStateAccess"
+    key            = "freeipa-master-tf-module/examples/basic_usage/terraform.tfstate"
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,8 @@
+output "client_security_group_id" {
+  value       = aws_security_group.ipa_clients.id
+  description = "The ID of the IPA client security group"
+}
+
 output "id" {
   value       = aws_instance.ipa.id
   description = "The EC2 instance ID corresponding to the IPA master"

--- a/server_security_group.tf
+++ b/server_security_group.tf
@@ -8,7 +8,7 @@ resource "aws_security_group" "ipa_servers" {
 
 # Allow HTTPS out anywhere.  This is needed to retrieve certificates
 # from S3.
-resource "aws_security_group_rule" "ipa_https_egress" {
+resource "aws_security_group_rule" "ipa_server_https_egress" {
   security_group_id = aws_security_group.ipa_servers.id
   type              = "egress"
   protocol          = "tcp"
@@ -18,7 +18,7 @@ resource "aws_security_group_rule" "ipa_https_egress" {
 }
 
 # TCP ingress rules for IPA
-resource "aws_security_group_rule" "ipa_tcp_ingress_trusted" {
+resource "aws_security_group_rule" "ipa_server_tcp_ingress_trusted" {
   count = length(local.ipa_tcp_ports)
 
   security_group_id = aws_security_group.ipa_servers.id
@@ -28,7 +28,7 @@ resource "aws_security_group_rule" "ipa_tcp_ingress_trusted" {
   from_port         = local.ipa_tcp_ports[count.index]
   to_port           = local.ipa_tcp_ports[count.index]
 }
-resource "aws_security_group_rule" "ipa_tcp_ingress_self" {
+resource "aws_security_group_rule" "ipa_server_tcp_ingress_self" {
   count = length(local.ipa_tcp_ports)
 
   security_group_id = aws_security_group.ipa_servers.id
@@ -38,9 +38,19 @@ resource "aws_security_group_rule" "ipa_tcp_ingress_self" {
   from_port         = local.ipa_tcp_ports[count.index]
   to_port           = local.ipa_tcp_ports[count.index]
 }
+resource "aws_security_group_rule" "ipa_server_tcp_ingress_clients" {
+  count = length(local.ipa_tcp_ports)
+
+  security_group_id        = aws_security_group.ipa_servers.id
+  type                     = "ingress"
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.ipa_clients.id
+  from_port                = local.ipa_tcp_ports[count.index]
+  to_port                  = local.ipa_tcp_ports[count.index]
+}
 
 # TCP egress rules for IPA
-resource "aws_security_group_rule" "ipa_tcp_egress_self" {
+resource "aws_security_group_rule" "ipa_server_tcp_egress_self" {
   count = length(local.ipa_tcp_ports)
 
   security_group_id = aws_security_group.ipa_servers.id
@@ -52,7 +62,7 @@ resource "aws_security_group_rule" "ipa_tcp_egress_self" {
 }
 
 # UDP ingress rules for IPA
-resource "aws_security_group_rule" "ipa_udp_ingress_trusted" {
+resource "aws_security_group_rule" "ipa_server_udp_ingress_trusted" {
   count = length(local.ipa_udp_ports)
 
   security_group_id = aws_security_group.ipa_servers.id
@@ -62,7 +72,7 @@ resource "aws_security_group_rule" "ipa_udp_ingress_trusted" {
   from_port         = local.ipa_udp_ports[count.index]
   to_port           = local.ipa_udp_ports[count.index]
 }
-resource "aws_security_group_rule" "ipa_udp_ingress_self" {
+resource "aws_security_group_rule" "ipa_server_udp_ingress_self" {
   count = length(local.ipa_udp_ports)
 
   security_group_id = aws_security_group.ipa_servers.id
@@ -72,9 +82,19 @@ resource "aws_security_group_rule" "ipa_udp_ingress_self" {
   from_port         = local.ipa_udp_ports[count.index]
   to_port           = local.ipa_udp_ports[count.index]
 }
+resource "aws_security_group_rule" "ipa_server_udp_ingress_clients" {
+  count = length(local.ipa_udp_ports)
+
+  security_group_id        = aws_security_group.ipa_servers.id
+  type                     = "ingress"
+  protocol                 = "udp"
+  source_security_group_id = aws_security_group.ipa_clients.id
+  from_port                = local.ipa_udp_ports[count.index]
+  to_port                  = local.ipa_udp_ports[count.index]
+}
 
 # UDP egress rules for IPA
-resource "aws_security_group_rule" "ipa_udp_egress_self" {
+resource "aws_security_group_rule" "ipa_server_udp_egress_self" {
   count = length(local.ipa_udp_ports)
 
   security_group_id = aws_security_group.ipa_servers.id


### PR DESCRIPTION
* Configure the client SG to allow egress to the server SG.  Configure the server SG to allow ingress from the client SG.
* Add the client SG as an output of the module.

Also update the example code to make use of the COOL Terraform account for state and such.