### PR TITLE
Change default value for variable specifying account that owns AMI

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ module "ipa_master" {
 
 | Name | Description |
 |------|-------------|
-| client_security_group_id | The ID of the IPA client security group |
-| id | The EC2 instance ID corresponding to the IPA master |
-| server_security_group_id | The ID of the IPA server security group |
+| client_security_group | The IPA client security group. |
+| master | The IPA master EC2 instance. |
+| server_security_group | The IPA server security group. |
 
 ## Contributing ##
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ module "ipa_master" {
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-------:|:--------:|
 | admin_pw | The admin password for the Kerberos admin role | string | | yes |
-| ami_owner_account_id | The ID of the AWS account that owns the FreeIPA server AMI | string | `344440683180` | no |
+| ami_owner_account_id | The ID of the AWS account that owns the FreeIPA server AMI, or \"self\" if the AMI is owned by the same account as the provisioner. | string | `self` | no |
 | associate_public_ip_address | Whether or not to associate a public IP address with the IPA master | bool | `false` | no |
 | aws_instance_type | The AWS instance type to deploy (e.g. t3.medium).  Two gigabytes of RAM is given as a minimum requirement for FreeIPA, but I have had intermittent problems when creating t3.small replicas. | string | `t3.medium` | no |
 | cert_bucket_name | The name of the AWS S3 bucket where certificates are stored | string | | yes |

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ module "ipa_master" {
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-------:|:--------:|
 | admin_pw | The admin password for the Kerberos admin role. | string | | yes |
-| ami_owner_account_id | The ID of the AWS account that owns the FreeIPA server AMI, or \"self\" if the AMI is owned by the same account as the provisioner. | string | `self` | no |
+| ami_owner_account_id | The ID of the AWS account that owns the FreeIPA server AMI, or ""self" if the AMI is owned by the same account as the provisioner. | string | `self` | no |
 | associate_public_ip_address | Whether or not to associate a public IP address with the IPA master. | bool | `false` | no |
 | aws_instance_type | The AWS instance type to deploy (e.g. t3.medium).  Two gigabytes of RAM is given as a minimum requirement for FreeIPA, but I have had intermittent problems when creating t3.small replicas. | string | `t3.medium` | no |
 | cert_bucket_name | The name of the AWS S3 bucket where certificates are stored. | string | | yes |

--- a/README.md
+++ b/README.md
@@ -44,23 +44,23 @@ module "ipa_master" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-------:|:--------:|
-| admin_pw | The admin password for the Kerberos admin role | string | | yes |
+| admin_pw | The admin password for the Kerberos admin role. | string | | yes |
 | ami_owner_account_id | The ID of the AWS account that owns the FreeIPA server AMI, or \"self\" if the AMI is owned by the same account as the provisioner. | string | `self` | no |
-| associate_public_ip_address | Whether or not to associate a public IP address with the IPA master | bool | `false` | no |
+| associate_public_ip_address | Whether or not to associate a public IP address with the IPA master. | bool | `false` | no |
 | aws_instance_type | The AWS instance type to deploy (e.g. t3.medium).  Two gigabytes of RAM is given as a minimum requirement for FreeIPA, but I have had intermittent problems when creating t3.small replicas. | string | `t3.medium` | no |
-| cert_bucket_name | The name of the AWS S3 bucket where certificates are stored | string | | yes |
-| cert_pw | The password used to protect the PKCS#12 certificates | string | | yes |
-| cert_read_role_arn | The ARN of the delegated role that allows the relevent certificates to be read from the appropriate S3 bucket | string | | yes |
-| directory_service_pw | The password for the IPA master's directory service | string | | yes |
-| domain | The domain for the IPA master (e.g. `example.com`) | string | | yes |
-| hostname | The hostname of the IPA master (e.g. `ipa.example.com`) | string | | yes |
-| private_reverse_zone_id | The zone ID corresponding to the private Route53 reverse zone where the PTR records related to the IPA master should be created (e.g. `ZKX36JXQ8W82L`) | string | | yes |
-| private_zone_id | The zone ID corresponding to the private Route53 zone where the Kerberos-related DNS records should be created (e.g. `ZKX36JXQ8W82L`) | string | | yes |
+| cert_bucket_name | The name of the AWS S3 bucket where certificates are stored. | string | | yes |
+| cert_pw | The password used to protect the PKCS#12 certificates. | string | | yes |
+| cert_read_role_arn | The ARN of the delegated role that allows the relevent certificates to be read from the appropriate S3 bucket. | string | | yes |
+| directory_service_pw | The password for the IPA master's directory service. | string | | yes |
+| domain | The domain for the IPA master (e.g. `example.com`). | string | | yes |
+| hostname | The hostname of the IPA master (e.g. `ipa.example.com`). | string | | yes |
+| private_reverse_zone_id | The zone ID corresponding to the private Route53 reverse zone where the PTR records related to the IPA master should be created (e.g. `ZKX36JXQ8W82L`). | string | | yes |
+| private_zone_id | The zone ID corresponding to the private Route53 zone where the Kerberos-related DNS records should be created (e.g. `ZKX36JXQ8W82L`). | string | | yes |
 | public_zone_id | The zone ID corresponding to the public Route53 zone where the Kerberos-related DNS records should be created (e.g. `ZKX36JXQ8W82L`).  Only required if a public IP address is associated with the IPA master (i.e. if associate_public_ip_address is true). | string | Empty string | no |
-| realm | The realm for the IPA server (e.g. `EXAMPLE.COM`) | string | | yes |
-| subnet_id | The ID of the AWS subnet into which to deploy the IPA master (e.g. `subnet-0123456789abcdef0`) | string | | yes |
-| tags | Tags to apply to all AWS resources created | map(string) | `{}` | no |
-| trusted_cidr_blocks | A list of the CIDR blocks outside the VPC that are allowed to access the IPA master (e.g. `[10.10.0.0/16, 10.11.0.0/16]`) | list(string) | `[]` | no |
+| realm | The realm for the IPA server (e.g. `EXAMPLE.COM`). | string | | yes |
+| subnet_id | The ID of the AWS subnet into which to deploy the IPA master (e.g. `subnet-0123456789abcdef0`). | string | | yes |
+| tags | Tags to apply to all AWS resources created. | map(string) | `{}` | no |
+| trusted_cidr_blocks | A list of the CIDR blocks outside the VPC that are allowed to access the IPA master (e.g. `[10.10.0.0/16, 10.11.0.0/16]`). | list(string) | `[]` | no |
 | ttl | The TTL value to use for Route53 DNS records (e.g. 86400).  A smaller value may be useful when the DNS records are changing often, for example when testing. | string | `86400` | no |
 
 ## Outputs ##

--- a/examples/basic_usage/README.md
+++ b/examples/basic_usage/README.md
@@ -1,4 +1,4 @@
-# Launch an IPA master and an IPA replica into a VPC #
+# Launch an IPA master into a VPC #
 
 ## Usage ##
 
@@ -12,6 +12,6 @@ Note that this example may create resources which cost money. Run
 
 | Name | Description |
 |------|-------------|
-| ipa_client_security_group_id | The ID corresponding to the IPA client security group |
-| ipa_server_security_group_id | The ID corresponding to the IPA server security group |
-| master_id | The EC2 instance ID corresponding to the IPA master |
+| ipa_client_security_group | The IPA client security group. |
+| ipa_server_security_group | The IPA server security group. |
+| master | The IPA master EC2 instance. |

--- a/examples/basic_usage/backend.tf
+++ b/examples/basic_usage/backend.tf
@@ -1,8 +1,8 @@
 terraform {
   backend "s3" {
     bucket         = "cisa-cool-terraform-state"
-    encrypt        = true
     dynamodb_table = "terraform-state-lock"
+    encrypt        = true
     key            = "freeipa-master-tf-module/examples/basic_usage/terraform.tfstate"
     profile        = "cool-terraform-backend"
     region         = "us-east-1"

--- a/examples/basic_usage/backend.tf
+++ b/examples/basic_usage/backend.tf
@@ -1,11 +1,10 @@
 terraform {
   backend "s3" {
-    encrypt        = true
     bucket         = "cisa-cool-terraform-state"
+    encrypt        = true
     dynamodb_table = "terraform-state-lock"
-    region         = "us-east-1"
-    profile        = "cool-user"
-    role_arn       = "arn:aws:iam::608004238745:role/TerraformStateAccess"
     key            = "freeipa-master-tf-module/examples/basic_usage/terraform.tfstate"
+    profile        = "cool-terraform-backend"
+    region         = "us-east-1"
   }
 }

--- a/examples/basic_usage/main.tf
+++ b/examples/basic_usage/main.tf
@@ -5,13 +5,13 @@ provider "aws" {
 
 provider "aws" {
   region  = "us-east-1"
-  profile = "default"
+  profile = "cool-olddns-route53fullaccess"
   alias   = "public_dns"
 }
 
 provider "aws" {
   region  = "us-east-1"
-  profile = "certreadrole-role"
+  profile = "cool-dns-provisioncertificatereadroles"
   alias   = "cert_read_role"
 }
 
@@ -111,6 +111,7 @@ module "ipa_master" {
   }
 
   admin_pw                    = "thepassword"
+  ami_owner_account_id        = "207871073513" # The COOL Images account
   associate_public_ip_address = true
   cert_bucket_name            = "cool-certificates"
   cert_pw                     = "lemmy"

--- a/examples/basic_usage/main.tf
+++ b/examples/basic_usage/main.tf
@@ -26,7 +26,7 @@ resource "aws_vpc" "the_vpc" {
 resource "aws_subnet" "master_subnet" {
   vpc_id            = aws_vpc.the_vpc.id
   cidr_block        = "10.99.48.0/24"
-  availability_zone = "us-east-2a"
+  availability_zone = "us-east-1a"
 }
 
 #-------------------------------------------------------------------------------

--- a/examples/basic_usage/main.tf
+++ b/examples/basic_usage/main.tf
@@ -89,7 +89,7 @@ module "certreadrole" {
   source = "github.com/cisagov/cert-read-role-tf-module"
 
   providers = {
-    aws = "aws.cert_read_role"
+    aws = aws.cert_read_role
   }
 
   account_ids = [
@@ -106,8 +106,8 @@ module "ipa_master" {
   source = "../../"
 
   providers = {
-    aws            = "aws"
-    aws.public_dns = "aws.public_dns"
+    aws            = aws
+    aws.public_dns = aws.public_dns
   }
 
   admin_pw                    = "thepassword"

--- a/examples/basic_usage/main.tf
+++ b/examples/basic_usage/main.tf
@@ -1,18 +1,18 @@
 provider "aws" {
-  region  = "us-east-2"
-  profile = "playground"
+  profile = "cool-sharedservices-provisionaccount"
+  region  = "us-east-1"
 }
 
 provider "aws" {
-  region  = "us-east-1"
-  profile = "cool-olddns-route53fullaccess"
   alias   = "public_dns"
+  profile = "cool-olddns-route53fullaccess"
+  region  = "us-east-1"
 }
 
 provider "aws" {
-  region  = "us-east-1"
-  profile = "cool-dns-provisioncertificatereadroles"
   alias   = "cert_read_role"
+  profile = "cool-dns-provisioncertificatereadroles"
+  region  = "us-east-1"
 }
 
 #-------------------------------------------------------------------------------
@@ -93,9 +93,9 @@ module "certreadrole" {
   }
 
   account_ids = [
-    "563873274798" # The playground account ID
+    "236526679726" # The COOL Users account
   ]
-  cert_bucket_name = "cool-certificates"
+  cert_bucket_name = "cisa-cool-certificates"
   hostname         = "ipa.cal23.cyber.dhs.gov"
 }
 
@@ -113,7 +113,7 @@ module "ipa_master" {
   admin_pw                    = "thepassword"
   ami_owner_account_id        = "207871073513" # The COOL Images account
   associate_public_ip_address = true
-  cert_bucket_name            = "cool-certificates"
+  cert_bucket_name            = "cisa-cool-certificates"
   cert_pw                     = "lemmy"
   cert_read_role_arn          = module.certreadrole.arn
   directory_service_pw        = "thepassword"

--- a/examples/basic_usage/main.tf
+++ b/examples/basic_usage/main.tf
@@ -85,6 +85,9 @@ data "aws_route53_zone" "public_zone" {
 #-------------------------------------------------------------------------------
 # Create a role that allows the master to read its certs from S3.
 #-------------------------------------------------------------------------------
+data "aws_caller_identity" "shared_services" {
+}
+
 module "certreadrole" {
   source = "github.com/cisagov/cert-read-role-tf-module"
 
@@ -93,7 +96,7 @@ module "certreadrole" {
   }
 
   account_ids = [
-    "236526679726" # The COOL Users account
+    data.aws_caller_identity.shared_services.account_id,
   ]
   cert_bucket_name = "cisa-cool-certificates"
   hostname         = "ipa.cal23.cyber.dhs.gov"

--- a/examples/basic_usage/main.tf
+++ b/examples/basic_usage/main.tf
@@ -118,7 +118,7 @@ module "ipa_master" {
   associate_public_ip_address = true
   cert_bucket_name            = "cisa-cool-certificates"
   cert_pw                     = "lemmy"
-  cert_read_role_arn          = module.certreadrole.arn
+  cert_read_role_arn          = module.certreadrole.role.arn
   directory_service_pw        = "thepassword"
   domain                      = "cal23.cyber.dhs.gov"
   hostname                    = "ipa.cal23.cyber.dhs.gov"

--- a/examples/basic_usage/outputs.tf
+++ b/examples/basic_usage/outputs.tf
@@ -1,14 +1,14 @@
-output "ipa_client_security_group_id" {
-  value       = module.ipa_master.client_security_group_id
-  description = "The ID corresponding to the IPA client security group"
+output "ipa_client_security_group" {
+  value       = module.ipa_master.client_security_group
+  description = "The IPA client security group."
 }
 
-output "ipa_server_security_group_id" {
-  value       = module.ipa_master.server_security_group_id
-  description = "The ID corresponding to the IPA server security group"
+output "ipa_server_security_group" {
+  value       = module.ipa_master.server_security_group
+  description = "The IPA server security group."
 }
 
-output "master_id" {
-  value       = module.ipa_master.id
-  description = "The EC2 instance ID corresponding to the IPA master"
+output "ipa_master" {
+  value       = module.ipa_master
+  description = "The IPA master EC2 instance."
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,14 +1,14 @@
-output "client_security_group_id" {
-  value       = aws_security_group.ipa_clients.id
-  description = "The ID of the IPA client security group"
+output "client_security_group" {
+  value       = aws_security_group.ipa_clients
+  description = "The IPA client security group."
 }
 
-output "id" {
-  value       = aws_instance.ipa.id
-  description = "The EC2 instance ID corresponding to the IPA master"
+output "master" {
+  value       = aws_instance.ipa
+  description = "The IPA master EC2 instance."
 }
 
-output "server_security_group_id" {
-  value       = aws_security_group.ipa_servers.id
-  description = "The ID of the IPA server security group"
+output "server_security_group" {
+  value       = aws_security_group.ipa_servers
+  description = "The IPA server security group."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -5,47 +5,47 @@
 # ------------------------------------------------------------------------------
 
 variable "admin_pw" {
-  description = "The password for the Kerberos admin role"
+  description = "The password for the Kerberos admin role."
 }
 
 variable "cert_bucket_name" {
-  description = "The name of the AWS S3 bucket where certificates are stored"
+  description = "The name of the AWS S3 bucket where certificates are stored."
 }
 
 variable "cert_pw" {
-  description = "The password used to protect the PKCS#12 certificates"
+  description = "The password used to protect the PKCS#12 certificates."
 }
 
 variable "cert_read_role_arn" {
-  description = "The ARN of the delegated role that allows the relevent certificates to be read from the appropriate S3 bucket"
+  description = "The ARN of the delegated role that allows the relevent certificates to be read from the appropriate S3 bucket."
 }
 
 variable "directory_service_pw" {
-  description = "The password for the IPA master's directory service"
+  description = "The password for the IPA master's directory service."
 }
 
 variable "domain" {
-  description = "The domain for the IPA master (e.g. example.com)"
+  description = "The domain for the IPA master (e.g. example.com)."
 }
 
 variable "hostname" {
-  description = "The hostname of the IPA master (e.g. ipa.example.com)"
+  description = "The hostname of the IPA master (e.g. ipa.example.com)."
 }
 
 variable "private_reverse_zone_id" {
-  description = "The zone ID corresponding to the private Route53 reverse zone where the PTR records related to the IPA master should be created (e.g. ZKX36JXQ8W82L)"
+  description = "The zone ID corresponding to the private Route53 reverse zone where the PTR records related to the IPA master should be created (e.g. ZKX36JXQ8W82L)."
 }
 
 variable "private_zone_id" {
-  description = "The zone ID corresponding to the private Route53 zone where the Kerberos-related DNS records should be created (e.g. ZKX36JXQ8W82L)"
+  description = "The zone ID corresponding to the private Route53 zone where the Kerberos-related DNS records should be created (e.g. ZKX36JXQ8W82L)."
 }
 
 variable "realm" {
-  description = "The realm for the IPA server (e.g. EXAMPLE.COM)"
+  description = "The realm for the IPA server (e.g. EXAMPLE.COM)."
 }
 
 variable "subnet_id" {
-  description = "The ID of the AWS subnet into which to deploy the IPA master (e.g. subnet-0123456789abcdef0)"
+  description = "The ID of the AWS subnet into which to deploy the IPA master (e.g. subnet-0123456789abcdef0)."
 }
 
 # ------------------------------------------------------------------------------
@@ -62,7 +62,7 @@ variable "ami_owner_account_id" {
 
 variable "associate_public_ip_address" {
   type        = bool
-  description = "Whether or not to associate a public IP address with the IPA master"
+  description = "Whether or not to associate a public IP address with the IPA master."
   default     = false
 }
 
@@ -78,13 +78,13 @@ variable "public_zone_id" {
 
 variable "tags" {
   type        = map(string)
-  description = "Tags to apply to all AWS resources created"
+  description = "Tags to apply to all AWS resources created."
   default     = {}
 }
 
 variable "trusted_cidr_blocks" {
   type        = list(string)
-  description = "A list of the CIDR blocks outside the VPC that are allowed to access the IPA servers (e.g. [\"10.10.0.0/16\", \"10.11.0.0/16\"])"
+  description = "A list of the CIDR blocks outside the VPC that are allowed to access the IPA servers (e.g. [\"10.10.0.0/16\", \"10.11.0.0/16\"])."
   default     = []
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -56,8 +56,8 @@ variable "subnet_id" {
 # ------------------------------------------------------------------------------
 
 variable "ami_owner_account_id" {
-  description = "The ID of the AWS account that owns the FreeIPA server AMI"
-  default     = "563873274798" # CISA NCATS Playground account
+  description = "The ID of the AWS account that owns the FreeIPA server AMI, or \"self\" if the AMI is owned by the same account as the provisioner."
+  default     = "self"
 }
 
 variable "associate_public_ip_address" {


### PR DESCRIPTION
## 🗣 Description

In this pull request I:
* Change the default value of the `ami_owner_account_id` variable specifying the account that owns the AMI
* Change outputs to be resources instead of IDs or ARNs

## 💭 Motivation and Context

We need to specify the `ami_owner_account_id` variable for COOL deployment, and I realized that the existing default value no longer made sense.

## 🧪 Testing

I verified that I could deploy the example code to production.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
