### PR TITLE
Add the AmazonSSMManagedInstanceCore policy to the instance role for the SSM agent

### DIFF
--- a/instance_role.tf
+++ b/instance_role.tf
@@ -46,8 +46,6 @@ resource "aws_iam_role_policy_attachment" "cloudwatch_agent_policy_attachment" {
 
 # Attach the SSM Agent policy to this role as well
 resource "aws_iam_role_policy_attachment" "ssm_agent_policy_attachment" {
-  provider = aws.provisionassessment
-
   role       = aws_iam_role.ipa.id
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }

--- a/instance_role.tf
+++ b/instance_role.tf
@@ -44,6 +44,14 @@ resource "aws_iam_role_policy_attachment" "cloudwatch_agent_policy_attachment" {
   policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
 }
 
+# Attach the SSM Agent policy to this role as well
+resource "aws_iam_role_policy_attachment" "ssm_agent_policy_attachment" {
+  provider = aws.provisionassessment
+
+  role       = aws_iam_role.ipa.id
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
 # The instance profile to be used by the IPA master EC2 instance.
 resource "aws_iam_instance_profile" "ipa" {
   role = aws_iam_role.ipa.name

--- a/locals.tf
+++ b/locals.tf
@@ -1,7 +1,6 @@
 locals {
   # The TCP ports that the IPA servers should listen on
   ipa_tcp_ports = [
-    22,  # SSH
     80,  # HTTP
     88,  # kinit
     443, # HTTPS


### PR DESCRIPTION
## 🗣 Description

This pull request adds the AWS-provided `AmazonSSMManagedInstanceCore` policy to the FreeIPA master instance role for the SSM agent.

## 💭 Motivation and Context

With [aws/amazon-ssm-agent](https://github.com/aws/amazon-ssm-agent) we can get a shell on any instance (with or without `ssh`) via the AWS control plane.  This means we do not need to open port 22 or even provide a public IP or Internet Gateway.

## 🧪 Testing

All the pre-commit hooks pass.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
