### PR TITLE
Have cloud-init create a file containing non-sensitive IPA config params

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # the repo. Unless a later match takes precedence,
 # these owners will be requested for review when someone
 # opens a pull request.
-*       @dav3r @felddy @hillaryj @jsf9k @mcdonnnj @cisagov/team-ois
+* @dav3r @jsf9k

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ all of which should be in this repository.
 
 If you want to report a bug or request a new feature, the most direct
 method is to [create an
-issue](https://github.com/cisagov/freeipa-master-tf-module/issues) in
+issue](https://github.com/cisagov/freeipa-server-tf-module/issues) in
 this repository.  We recommend that you first search through existing
 issues (both open and closed) to check if your particular issue has
 already been reported.  If it has then you might want to add a comment
@@ -25,7 +25,7 @@ one.
 ## Pull requests ##
 
 If you choose to [submit a pull
-request](https://github.com/cisagov/freeipa-master-tf-module/pulls),
+request](https://github.com/cisagov/freeipa-server-tf-module/pulls),
 you will notice that our continuous integration (CI) system runs a
 fairly extensive set of linters and syntax checkers.  Your pull
 request may fail these checks, and that's OK.  If you want you can
@@ -99,9 +99,9 @@ can create and configure the Python virtual environment with these
 commands:
 
 ```console
-cd freeipa-master-tf-module
-pyenv virtualenv <python_version_to_use> freeipa-master-tf-module
-pyenv local freeipa-master-tf-module
+cd freeipa-server-tf-module
+pyenv virtualenv <python_version_to_use> freeipa-server-tf-module
+pyenv local freeipa-server-tf-module
 pip install --requirement requirements-dev.txt
 ```
 

--- a/README.md
+++ b/README.md
@@ -7,16 +7,30 @@ A Terraform module for deploying a FreeIPA server.
 ## Usage ##
 
 ```hcl
-module "ipa_master" {
+module "ipa0" {
   source = "github.com/cisagov/freeipa-master-tf-module"
 
-  aws_instance_type   = "t3.large"
-  domain              = "example.com"
-  hostname            = "ipa.example.com"
-  realm               = "EXAMPLE.COM"
-  security_group_ids  = ["sg-51530134", "sg-51530245"]
-  subnet_id           = aws_subnet.master_subnet.id
-  tags                = {
+  domain               = "example.com"
+  hostname             = "ipa.example.com"
+  ip                   = "10.10.10.4"
+  realm                = "EXAMPLE.COM"
+  security_group_ids   = ["sg-51530134", "sg-51530245"]
+  subnet_id            = aws_subnet.first_subnet.id
+  tags                 = {
+    Key1 = "Value1"
+    Key2 = "Value2"
+  }
+}
+
+module "ipa1" {
+  source = "github.com/cisagov/freeipa-master-tf-module"
+
+  domain               = "example.com"
+  hostname             = "ipa.example.com"
+  ip                   = "10.10.10.5"
+  security_group_ids   = ["sg-51530134", "sg-51530245"]
+  subnet_id            = aws_subnet.second_subnet.id
+  tags                 = {
     Key1 = "Value1"
     Key2 = "Value2"
   }
@@ -38,6 +52,7 @@ module "ipa_master" {
 | Name | Version |
 |------|---------|
 | aws | n/a |
+| template | n/a |
 
 ## Inputs ##
 
@@ -47,7 +62,8 @@ module "ipa_master" {
 | aws_instance_type | The AWS instance type to deploy (e.g. t3.medium).  Two gigabytes of RAM is given as a minimum requirement for FreeIPA, but I have had intermittent problems when creating t3.small replicas. | `string` | `t3.medium` | no |
 | domain | The domain for the IPA server (e.g. example.com). | `string` | n/a | yes |
 | hostname | The hostname of the IPA server (e.g. ipa.example.com). | `string` | n/a | yes |
-| realm | The realm for the IPA server (e.g. EXAMPLE.COM). | `string` | n/a | yes |
+| ip | The IP address to assign the IPA server (e.g. 10.10.10.4).  Note that the IP address must be contained inside the CIDR block corresponding to subnet-id, and AWS reserves the first four and very last IP addresses. | `string` | n/a | yes |
+| realm | The realm for the IPA server (e.g. EXAMPLE.COM).  Only used if this IPA server IS NOT intended to be a replica. | `string` | `EXAMPLE.COM` | no |
 | security_group_ids | A list of IDs corresponding to security groups to which the server should belong (e,g, ["sg-51530134", "sg-51530245"]).  Note that these security groups must exist in the same VPC as the server. | `list(string)` | `[]` | no |
 | subnet_id | The ID of the AWS subnet into which to deploy the IPA server (e.g. subnet-0123456789abcdef0). | `string` | n/a | yes |
 | tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
@@ -62,8 +78,7 @@ module "ipa_master" {
 
 Running `pre-commit` requires running `terraform init` in every
 directory that contains Terraform code. In this repository, these are
-the main directory and the `dns` and `dns/route53` directories under
-the main directory, as well as every directory under `examples/`.
+the main directory and every directory under `examples/`.
 
 ## Contributing ##
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# freeipa-master-tf-module #
+# freeipa-server-tf-module #
 
-[![GitHub Build Status](https://github.com/cisagov/freeipa-master-tf-module/workflows/build/badge.svg)](https://github.com/cisagov/freeipa-master-tf-module/actions)
+[![GitHub Build Status](https://github.com/cisagov/freeipa-server-tf-module/workflows/build/badge.svg)](https://github.com/cisagov/freeipa-server-tf-module/actions)
 
 A Terraform module for deploying a FreeIPA server.
 
@@ -8,7 +8,7 @@ A Terraform module for deploying a FreeIPA server.
 
 ```hcl
 module "ipa0" {
-  source = "github.com/cisagov/freeipa-master-tf-module"
+  source = "github.com/cisagov/freeipa-server-tf-module"
 
   domain               = "example.com"
   hostname             = "ipa.example.com"
@@ -23,7 +23,7 @@ module "ipa0" {
 }
 
 module "ipa1" {
-  source = "github.com/cisagov/freeipa-master-tf-module"
+  source = "github.com/cisagov/freeipa-server-tf-module"
 
   domain               = "example.com"
   hostname             = "ipa.example.com"
@@ -39,7 +39,7 @@ module "ipa1" {
 
 ## Examples ##
 
-* [Basic usage](https://github.com/cisagov/freeipa-master-tf-module/tree/develop/examples/basic_usage)
+* [Basic usage](https://github.com/cisagov/freeipa-server-tf-module/tree/develop/examples/basic_usage)
 
 ## Requirements ##
 

--- a/cloud-init/freeipa-vars.tpl.yml
+++ b/cloud-init/freeipa-vars.tpl.yml
@@ -1,0 +1,9 @@
+---
+write_files:
+  - path: /var/lib/cloud/instance/freeipa-vars.sh
+    permissions: '0600'
+    owner: root:root
+    content: |
+      domain=${domain}
+      hostname=${hostname}
+      realm=${realm}

--- a/cloud_init.tf
+++ b/cloud_init.tf
@@ -1,0 +1,28 @@
+data "template_cloudinit_config" "configure_freeipa" {
+  gzip          = true
+  base64_encode = true
+
+  #-----------------------------------------------------------------------------
+  # Cloud Config parts
+  #-----------------------------------------------------------------------------
+
+  # Note: All the cloud-config parts will write to the same file on
+  # the instance at boot. To prevent one part from clobbering another,
+  # you must specify a merge_type.  See:
+  # https://cloudinit.readthedocs.io/en/latest/topics/merging.html#built-in-mergers
+  #
+  # The filename parameters are only used to identify the mime-part
+  # headers in the user-data.
+
+  part {
+    filename     = "freeipa-vars.yml"
+    content_type = "text/cloud-config"
+    content = templatefile(
+      "${path.module}/cloud-init/freeipa-vars.tpl.yml", {
+        domain   = var.domain
+        hostname = var.hostname
+        realm    = var.realm
+    })
+    merge_type = "list(append)+dict(recurse_array)+str()"
+  }
+}

--- a/ec2.tf
+++ b/ec2.tf
@@ -5,7 +5,9 @@ resource "aws_instance" "ipa" {
   availability_zone           = data.aws_subnet.the_subnet.availability_zone
   subnet_id                   = var.subnet_id
   associate_public_ip_address = false
+  private_ip                  = var.ip
   vpc_security_group_ids      = var.security_group_ids
+  user_data_base64            = data.template_cloudinit_config.configure_freeipa.rendered
   iam_instance_profile        = aws_iam_instance_profile.ipa.name
   tags                        = var.tags
   volume_tags                 = var.tags

--- a/examples/basic_usage/README.md
+++ b/examples/basic_usage/README.md
@@ -1,4 +1,4 @@
-# Launch an IPA master into a VPC #
+# Launch an IPA server into a VPC #
 
 ## Usage ##
 

--- a/examples/basic_usage/backend.tf
+++ b/examples/basic_usage/backend.tf
@@ -3,7 +3,7 @@ terraform {
     bucket         = "cisa-cool-terraform-state"
     dynamodb_table = "terraform-state-lock"
     encrypt        = true
-    key            = "freeipa-master-tf-module/examples/basic_usage/terraform.tfstate"
+    key            = "freeipa-server-tf-module/examples/basic_usage/terraform.tfstate"
     profile        = "cool-terraform-backend"
     region         = "us-east-1"
   }

--- a/examples/basic_usage/main.tf
+++ b/examples/basic_usage/main.tf
@@ -47,6 +47,7 @@ module "ipa" {
   ami_owner_account_id = "207871073513" # The COOL Images account
   domain               = "cal23.cyber.dhs.gov"
   hostname             = "ipa.cal23.cyber.dhs.gov"
+  ip                   = "10.99.48.4"
   realm                = "CAL23.CYBER.DHS.GOV"
   subnet_id            = aws_subnet.subnet.id
   tags = {

--- a/variables.tf
+++ b/variables.tf
@@ -14,9 +14,9 @@ variable "hostname" {
   description = "The hostname of the IPA server (e.g. ipa.example.com)."
 }
 
-variable "realm" {
+variable "ip" {
   type        = string
-  description = "The realm for the IPA server (e.g. EXAMPLE.COM)."
+  description = "The IP address to assign the IPA server (e.g. 10.10.10.4).  Note that the IP address must be contained inside the CIDR block corresponding to subnet-id, and AWS reserves the first four and very last IP addresses.  We have to assign an IP in order to break the dependency of DNS record resources on the corresponding EC2 resources; otherwise, it is impossible to update the IPA servers one by one as is required when a new AMI is created."
 }
 
 variable "subnet_id" {
@@ -27,8 +27,8 @@ variable "subnet_id" {
 # ------------------------------------------------------------------------------
 # Optional parameters
 #
-# These parameters have reasonable defaults, or their requirement is
-# dependent on the values of the other parameters.
+# These parameters have reasonable defaults, or they are only used in
+# certain cases.
 # ------------------------------------------------------------------------------
 
 variable "ami_owner_account_id" {
@@ -41,6 +41,12 @@ variable "aws_instance_type" {
   type        = string
   description = "The AWS instance type to deploy (e.g. t3.medium).  Two gigabytes of RAM is given as a minimum requirement for FreeIPA, but I have had intermittent problems when creating t3.small replicas."
   default     = "t3.medium"
+}
+
+variable "realm" {
+  type        = string
+  description = "The realm for the IPA server (e.g. EXAMPLE.COM).  Only used if this IPA server IS NOT intended to be a replica."
+  default     = "EXAMPLE.COM"
 }
 
 variable "security_group_ids" {


### PR DESCRIPTION
## 🗣 Description

This pull request:
* Adds cloud-init code to create a simple `bash` file defining the non-sensitive IPA configuration paramaters.
* Forces the user to supply an IP address for the IPA server.
* Makes `realm` an optional variable, since it is not needed for replicas.

## 💭 Motivation and Context

These changes are needed because:
* The cloud-init change is necessary because we want to make the installation of an IPA master or replica as easy and as automated as possible, but at the same time we do not want to leave sensitive data such as passwords lying around on disk or in EC2 metadata (which is where the cloud-init userdata is stored).
* It is necessary to force the user to supply the IP address for the IPA server in order to break the dependency of DNS record resources on EC2 instance resources; otherwise, it is impossible to replace the IPA servers one by one as is required when a new FreeIPA server AMI is made available.

See also cisagov/ansible-role-freeipa-server#10 and cisagov/cool-sharedservices-freeipa#14.

## 🧪 Testing

I have used this code to successfully redeploy the FreeIPA server cluster in our staging environment.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
