### PR TITLE
Upgrade to version 3.0 of the AWS provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,15 +46,15 @@ module "ipa1" {
 | Name | Version |
 |------|---------|
 | terraform | ~> 0.12.0 |
-| aws | ~> 2.0 |
-| template | ~> 2.1 |
+| aws | ~> 3.0 |
+| cloudinit | ~> 2.0 |
 
 ## Providers ##
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
-| template | ~> 2.1 |
+| aws | ~> 3.0 |
+| cloudinit | ~> 2.0 |
 
 ## Inputs ##
 
@@ -66,7 +66,7 @@ module "ipa1" {
 | hostname | The hostname of the IPA server (e.g. ipa.example.com). | `string` | n/a | yes |
 | ip | The IP address to assign the IPA server (e.g. 10.10.10.4).  Note that the IP address must be contained inside the CIDR block corresponding to subnet-id, and AWS reserves the first four and very last IP addresses.  We have to assign an IP in order to break the dependency of DNS record resources on the corresponding EC2 resources; otherwise, it is impossible to update the IPA servers one by one as is required when a new AMI is created. | `string` | n/a | yes |
 | realm | The realm for the IPA server (e.g. EXAMPLE.COM).  Only used if this IPA server IS NOT intended to be a replica. | `string` | `EXAMPLE.COM` | no |
-| security_group_ids | A list of IDs corresponding to security groups to which the server should belong (e,g, ["sg-51530134", "sg-51530245"]).  Note that these security groups must exist in the same VPC as the server. | `list(string)` | `[]` | no |
+| security_group_ids | A list of IDs corresponding to security groups to which the server should belong (e.g. ["sg-51530134", "sg-51530245"]).  Note that these security groups must exist in the same VPC as the server. | `list(string)` | `[]` | no |
 | subnet_id | The ID of the AWS subnet into which to deploy the IPA server (e.g. subnet-0123456789abcdef0). | `string` | n/a | yes |
 | tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
 

--- a/cloud_init.tf
+++ b/cloud_init.tf
@@ -1,4 +1,4 @@
-data "template_cloudinit_config" "configure_freeipa" {
+data "cloudinit_config" "configure_freeipa" {
   gzip          = true
   base64_encode = true
 

--- a/ec2.tf
+++ b/ec2.tf
@@ -7,7 +7,7 @@ resource "aws_instance" "ipa" {
   associate_public_ip_address = false
   private_ip                  = var.ip
   vpc_security_group_ids      = var.security_group_ids
-  user_data_base64            = data.template_cloudinit_config.configure_freeipa.rendered
+  user_data_base64            = data.cloudinit_config.configure_freeipa.rendered
   iam_instance_profile        = aws_iam_instance_profile.ipa.name
   tags                        = var.tags
   volume_tags                 = var.tags

--- a/variables.tf
+++ b/variables.tf
@@ -51,7 +51,7 @@ variable "realm" {
 
 variable "security_group_ids" {
   type        = list(string)
-  description = "A list of IDs corresponding to security groups to which the server should belong (e,g, [\"sg-51530134\", \"sg-51530245\"]).  Note that these security groups must exist in the same VPC as the server."
+  description = "A list of IDs corresponding to security groups to which the server should belong (e.g. [\"sg-51530134\", \"sg-51530245\"]).  Note that these security groups must exist in the same VPC as the server."
   default     = []
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -6,7 +6,7 @@ terraform {
   # major version currently being used.  This practice will help us
   # avoid unwelcome surprises.
   required_providers {
-    aws      = "~> 2.0"
-    template = "~> 2.1"
+    aws       = "~> 3.0"
+    cloudinit = "~> 2.0"
   }
 }


### PR DESCRIPTION
## 🗣 Description

This pull request:
* Updates this Terraform module to use version 3.X of the AWS provider.
* Updates this Terraform module to use the [cloudinit provider](https://registry.terraform.io/providers/hashicorp/cloudinit/latest) instead of the deprecated [template provider](https://registry.terraform.io/providers/hashicorp/template/latest).

## 💭 Motivation and Context

In cisagov/cool-sharedservices-freeipa#25 we want to upgrade the [cisagov/cool-sharedservices-freeipa](https://github.com/cisagov/cool-sharedservices-freeipa) code to use version 3.X of the AWS provider.  This repository is a dependency of that one, and therefore it must be upgraded as well.

## 🧪 Testing

I successfully ran a `terraform apply` for [cisagov/cool-sharedservices-freeipa](https://github.com/cisagov/cool-sharedservices-freeipa) in our staging COOL environment using these changes and those in cisagov/cool-sharedservices-freeipa#25.  No resources needed to be changed.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [x] Update Terraform provider

## ✅ Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
