### PR TITLE
Add code to link Nessus Agent in cloud-init

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,16 @@ A Terraform module for deploying a FreeIPA server.
 module "ipa0" {
   source = "github.com/cisagov/freeipa-server-tf-module"
 
-  domain               = "example.com"
-  hostname             = "ipa.example.com"
-  ip                   = "10.10.10.4"
-  realm                = "EXAMPLE.COM"
-  security_group_ids   = ["sg-51530134", "sg-51530245"]
-  subnet_id            = aws_subnet.first_subnet.id
-  tags                 = {
+  domain              = "example.com"
+  hostname            = "ipa.example.com"
+  ip                  = "10.10.10.4"
+  nessus_hostname_key = "/thulsa/doom/nessus/hostname"
+  nessus_key_key      = "/thulsa/doom/nessus/key"
+  nessus_port_key     = "/thulsa/doom/nessus/port"
+  realm               = "EXAMPLE.COM"
+  security_group_ids  = ["sg-51530134", "sg-51530245"]
+  subnet_id           = aws_subnet.first_subnet.id
+  tags                = {
     Key1 = "Value1"
     Key2 = "Value2"
   }
@@ -25,12 +28,15 @@ module "ipa0" {
 module "ipa1" {
   source = "github.com/cisagov/freeipa-server-tf-module"
 
-  domain               = "example.com"
-  hostname             = "ipa.example.com"
-  ip                   = "10.10.10.5"
-  security_group_ids   = ["sg-51530134", "sg-51530245"]
-  subnet_id            = aws_subnet.second_subnet.id
-  tags                 = {
+  domain              = "example.com"
+  hostname            = "ipa.example.com"
+  ip                  = "10.10.10.5"
+  nessus_hostname_key = "/thulsa/doom/nessus/hostname"
+  nessus_key_key      = "/thulsa/doom/nessus/key"
+  nessus_port_key     = "/thulsa/doom/nessus/port"
+  security_group_ids  = ["sg-51530134", "sg-51530245"]
+  subnet_id           = aws_subnet.second_subnet.id
+  tags                = {
     Key1 = "Value1"
     Key2 = "Value2"
   }
@@ -92,9 +98,9 @@ module "ipa1" {
 | ip | The IP address to assign the IPA server (e.g. 10.10.10.4).  Note that the IP address must be contained inside the CIDR block corresponding to subnet-id, and AWS reserves the first four and very last IP addresses.  We have to assign an IP in order to break the dependency of DNS record resources on the corresponding EC2 resources; otherwise, it is impossible to update the IPA servers one by one as is required when a new AMI is created. | `string` | n/a | yes |
 | nessus\_agent\_install\_path | The install path of Nessus Agent (e.g. /opt/nessus\_agent). | `string` | `"/opt/nessus_agent"` | no |
 | nessus\_groups | A list of strings, each of which is the name of a group in the CDM Tenable Nessus server that the Nessus Agent should join (e.g. ["group1", "group2"]). | `list(string)` | `["COOL_Fed_32"]` | no |
-| nessus\_hostname\_key | The SSM Parameter Store key whose corresponding value contains the hostname of the CDM Tenable Nessus server to which the Nessus Agent should link (e.g. /cdm/nessus\_hostname). | `string` | `"/cdm/nessus_hostname"` | no |
-| nessus\_key\_key | The SSM Parameter Store key whose corresponding value contains the secret key that the Nessus Agent should use when linking with the CDM Tenable Nessus server (e.g. /cdm/nessus\_key). | `string` | `"/cdm/nessus_key"` | no |
-| nessus\_port\_key | The SSM Parameter Store key whose corresponding value contains the port to which the Nessus Agent should connect when linking with the CDM Tenable Nessus server (e.g. /cdm/nessus\_port). | `string` | `"/cdm/nessus_port"` | no |
+| nessus\_hostname\_key | The SSM Parameter Store key whose corresponding value contains the hostname of the CDM Tenable Nessus server to which the Nessus Agent should link (e.g. /cdm/nessus/hostname). | `string` | n/a | yes |
+| nessus\_key\_key | The SSM Parameter Store key whose corresponding value contains the secret key that the Nessus Agent should use when linking with the CDM Tenable Nessus server (e.g. /cdm/nessus/key). | `string` | n/a | yes |
+| nessus\_port\_key | The SSM Parameter Store key whose corresponding value contains the port to which the Nessus Agent should connect when linking with the CDM Tenable Nessus server (e.g. /cdm/nessus/port). | `string` | n/a | yes |
 | realm | The realm for the IPA server (e.g. EXAMPLE.COM).  Only used if this IPA server IS NOT intended to be a replica. | `string` | `"EXAMPLE.COM"` | no |
 | security\_group\_ids | A list of IDs corresponding to security groups to which the server should belong (e.g. ["sg-51530134", "sg-51530245"]).  Note that these security groups must exist in the same VPC as the server. | `list(string)` | `[]` | no |
 | subnet\_id | The ID of the AWS subnet into which to deploy the IPA server (e.g. subnet-0123456789abcdef0). | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ module "ipa0" {
   source = "github.com/cisagov/freeipa-server-tf-module"
 
   domain              = "example.com"
-  hostname            = "ipa.example.com"
+  hostname            = "ipa0.example.com"
   ip                  = "10.10.10.4"
   nessus_hostname_key = "/thulsa/doom/nessus/hostname"
   nessus_key_key      = "/thulsa/doom/nessus/key"
@@ -29,7 +29,7 @@ module "ipa1" {
   source = "github.com/cisagov/freeipa-server-tf-module"
 
   domain              = "example.com"
-  hostname            = "ipa.example.com"
+  hostname            = "ipa1.example.com"
   ip                  = "10.10.10.5"
   nessus_hostname_key = "/thulsa/doom/nessus/hostname"
   nessus_key_key      = "/thulsa/doom/nessus/key"

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ module "ipa1" {
 | [aws_iam_role_policy_attachment.ssm_agent_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_instance.ipa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
 | [aws_ami.freeipa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
+| [aws_arn.subnet](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/arn) | data source |
+| [aws_caller_identity.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.assume_delegated_role_policy_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.assume_role_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_subnet.the_subnet](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
@@ -88,6 +90,7 @@ module "ipa1" {
 | domain | The domain for the IPA server (e.g. example.com). | `string` | n/a | yes |
 | hostname | The hostname of the IPA server (e.g. ipa.example.com). | `string` | n/a | yes |
 | ip | The IP address to assign the IPA server (e.g. 10.10.10.4).  Note that the IP address must be contained inside the CIDR block corresponding to subnet-id, and AWS reserves the first four and very last IP addresses.  We have to assign an IP in order to break the dependency of DNS record resources on the corresponding EC2 resources; otherwise, it is impossible to update the IPA servers one by one as is required when a new AMI is created. | `string` | n/a | yes |
+| nessus\_agent\_install\_path | The install path of Nessus Agent (e.g. /opt/nessus\_agent). | `string` | `"/opt/nessus_agent"` | no |
 | nessus\_groups | A list of strings, each of which is the name of a group in the CDM Tenable Nessus server that the Nessus Agent should join (e.g. ["group1", "group2"]). | `list(string)` | `["COOL_Fed_32"]` | no |
 | nessus\_hostname\_key | The SSM Parameter Store key whose corresponding value contains the hostname of the CDM Tenable Nessus server to which the Nessus Agent should link (e.g. /cdm/nessus\_hostname). | `string` | `"/cdm/nessus_hostname"` | no |
 | nessus\_key\_key | The SSM Parameter Store key whose corresponding value contains the secret key that the Nessus Agent should use when linking with the CDM Tenable Nessus server (e.g. /cdm/nessus\_key). | `string` | `"/cdm/nessus_key"` | no |

--- a/README.md
+++ b/README.md
@@ -56,18 +56,45 @@ module "ipa1" {
 | aws | ~> 3.0 |
 | cloudinit | ~> 2.0 |
 
+## Modules ##
+
+| Name | Source | Version |
+|------|--------|---------|
+| read\_ssm\_parameters | github.com/cisagov/ssm-read-role-tf-module |  |
+
+## Resources ##
+
+| Name | Type |
+|------|------|
+| [aws_iam_instance_profile.ipa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
+| [aws_iam_role.ipa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.assume_delegated_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy_attachment.cloudwatch_agent_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.ssm_agent_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_instance.ipa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
+| [aws_ami.freeipa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
+| [aws_iam_policy_document.assume_delegated_role_policy_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.assume_role_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_subnet.the_subnet](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
+| [aws_vpc.the_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
+| [cloudinit_config.configure_freeipa](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config) | data source |
+
 ## Inputs ##
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| ami_owner_account_id | The ID of the AWS account that owns the FreeIPA server AMI, or "self" if the AMI is owned by the same account as the provisioner. | `string` | `self` | no |
-| aws_instance_type | The AWS instance type to deploy (e.g. t3.medium).  Two gigabytes of RAM is given as a minimum requirement for FreeIPA, but I have had intermittent problems when creating t3.small replicas. | `string` | `t3.medium` | no |
+| ami\_owner\_account\_id | The ID of the AWS account that owns the FreeIPA server AMI, or "self" if the AMI is owned by the same account as the provisioner. | `string` | `"self"` | no |
+| aws\_instance\_type | The AWS instance type to deploy (e.g. t3.medium).  Two gigabytes of RAM is given as a minimum requirement for FreeIPA, but I have had intermittent problems when creating t3.small replicas. | `string` | `"t3.medium"` | no |
 | domain | The domain for the IPA server (e.g. example.com). | `string` | n/a | yes |
 | hostname | The hostname of the IPA server (e.g. ipa.example.com). | `string` | n/a | yes |
 | ip | The IP address to assign the IPA server (e.g. 10.10.10.4).  Note that the IP address must be contained inside the CIDR block corresponding to subnet-id, and AWS reserves the first four and very last IP addresses.  We have to assign an IP in order to break the dependency of DNS record resources on the corresponding EC2 resources; otherwise, it is impossible to update the IPA servers one by one as is required when a new AMI is created. | `string` | n/a | yes |
-| realm | The realm for the IPA server (e.g. EXAMPLE.COM).  Only used if this IPA server IS NOT intended to be a replica. | `string` | `EXAMPLE.COM` | no |
-| security_group_ids | A list of IDs corresponding to security groups to which the server should belong (e.g. ["sg-51530134", "sg-51530245"]).  Note that these security groups must exist in the same VPC as the server. | `list(string)` | `[]` | no |
-| subnet_id | The ID of the AWS subnet into which to deploy the IPA server (e.g. subnet-0123456789abcdef0). | `string` | n/a | yes |
+| nessus\_groups | A list of strings, each of which is the name of a group in the CDM Tenable Nessus server that the Nessus Agent should join (e.g. ["group1", "group2"]). | `list(string)` | `["COOL_Fed_32"]` | no |
+| nessus\_hostname\_key | The SSM Parameter Store key whose corresponding value contains the hostname of the CDM Tenable Nessus server to which the Nessus Agent should link (e.g. /cdm/nessus\_hostname). | `string` | `"/cdm/nessus_hostname"` | no |
+| nessus\_key\_key | The SSM Parameter Store key whose corresponding value contains the secret key that the Nessus Agent should use when linking with the CDM Tenable Nessus server (e.g. /cdm/nessus\_key). | `string` | `"/cdm/nessus_key"` | no |
+| nessus\_port\_key | The SSM Parameter Store key whose corresponding value contains the port to which the Nessus Agent should connect when linking with the CDM Tenable Nessus server (e.g. /cdm/nessus\_port). | `string` | `"/cdm/nessus_port"` | no |
+| realm | The realm for the IPA server (e.g. EXAMPLE.COM).  Only used if this IPA server IS NOT intended to be a replica. | `string` | `"EXAMPLE.COM"` | no |
+| security\_group\_ids | A list of IDs corresponding to security groups to which the server should belong (e.g. ["sg-51530134", "sg-51530245"]).  Note that these security groups must exist in the same VPC as the server. | `list(string)` | `[]` | no |
+| subnet\_id | The ID of the AWS subnet into which to deploy the IPA server (e.g. subnet-0123456789abcdef0). | `string` | n/a | yes |
 | tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
 
 ## Outputs ##

--- a/caller_identity.tf
+++ b/caller_identity.tf
@@ -1,0 +1,6 @@
+# ------------------------------------------------------------------------------
+# Retrieve the effective Account ID, User ID, and ARN in which
+# Terraform is authorized.  This is used to calculate the session
+# names for assumed roles.
+# ------------------------------------------------------------------------------
+data "aws_caller_identity" "main" {}

--- a/cloud-init/link-nessus-agent.py
+++ b/cloud-init/link-nessus-agent.py
@@ -6,7 +6,10 @@ This file is a template.  It must be processed by Terraform.
 """
 
 # Standard Python Libraries
-import subprocess
+# Bandit triggers B404 here, but we're only using subprocess.run() and
+# doing so safely.  For more details on B404 see here:
+# https://bandit.readthedocs.io/en/latest/blacklists/blacklist_imports.html#b404-import-subprocess
+import subprocess  # nosec
 
 # Third-Party Libraries
 import boto3
@@ -69,4 +72,8 @@ link_cmd = [
     f"--port={nessus_port}",
     f"--groups={NESSUS_GROUPS}",
 ]
-subprocess.run(link_cmd)
+# Bandit triggers B603 here, but we're using subprocess.run() safely
+# here, since the variable content in link_cmd comes directly from SSM
+# Parameter Store.  For more details on B603 see here:
+# https://bandit.readthedocs.io/en/latest/plugins/b603_subprocess_without_shell_equals_true.html
+subprocess.run(link_cmd)  # nosec

--- a/cloud-init/link-nessus-agent.py
+++ b/cloud-init/link-nessus-agent.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+"""Link Nessus Agent to Tenable/Nessus server.
+
+This file is a template.  It must be processed by Terraform.
+"""
+
+# Standard Python Libraries
+import subprocess
+
+# Third-Party Libraries
+import boto3
+
+# Inputs from terraform
+NESSUS_GROUPS = "${nessus_groups}"
+NESSUS_HOSTNAME_KEY = "${nessus_hostname_key}"
+NESSUS_KEY_KEY = "${nessus_key_key}"
+NESSUS_PORT_KEY = "${nessus_port_key}"
+SSM_READ_ROLE_ARN = "${ssm_read_role_arn}"
+
+# Create STS client
+sts_client = boto3.client("sts")
+
+# Assume the role that can read the SSM Parameter Store parameters
+stsresponse = sts_client.assume_role(
+    RoleArn=SSM_READ_ROLE_ARN, RoleSessionName="nessus_agent_linking"
+)
+newsession_id = stsresponse["Credentials"]["AccessKeyId"]
+newsession_key = stsresponse["Credentials"]["SecretAccessKey"]
+newsession_token = stsresponse["Credentials"]["SessionToken"]
+
+# Create a new client to access SSM Parameter Store using the
+# temporary credentials
+ssm_client = boto3.client(
+    "ssm",
+    aws_access_key_id=newsession_id,
+    aws_secret_access_key=newsession_key,
+    aws_session_token=newsession_token,
+)
+
+# Get the values of the SSM Parameter Store parameters
+nessus_hostname_response = ssm_client.get_parameter(
+    Name=NESSUS_HOSTNAME_KEY,
+    WithDecryption=True,
+)
+nessus_hostname = nessus_hostname_response["Value"]
+
+nessus_key_response = ssm_client.get_parameter(
+    Name=NESSUS_KEY_KEY,
+    WithDecryption=True,
+)
+nessus_key = nessus_key_response["Value"]
+
+nessus_port_response = ssm_client.get_parameter(
+    Name=NESSUS_PORT_KEY,
+    WithDecryption=True,
+)
+nessus_port = nessus_port_response["Value"]
+
+# Link the Nessus Agent
+link_cmd = [
+    "/opt/nessus/sbin/nessuscli",
+    "agent",
+    "link",
+    f"--key={nessus_key}",
+    f"--host={nessus_hostname}",
+    f"--port={nessus_port}",
+    f"--groups={NESSUS_GROUPS}",
+]
+subprocess.run(link_cmd)

--- a/cloud-init/link-nessus-agent.py
+++ b/cloud-init/link-nessus-agent.py
@@ -61,7 +61,7 @@ nessus_port = nessus_port_response["Parameter"]["Value"]
 
 # Link the Nessus Agent
 link_cmd = [
-    "/opt/nessus/sbin/nessuscli",
+    "/opt/nessus_agent/sbin/nessuscli",
     "agent",
     "link",
     f"--key={nessus_key}",

--- a/cloud-init/link-nessus-agent.py
+++ b/cloud-init/link-nessus-agent.py
@@ -10,71 +10,77 @@ This file is a template.  It must be processed by Terraform.
 # doing so safely.  For more details on B404 see here:
 # https://bandit.readthedocs.io/en/latest/blacklists/blacklist_imports.html#b404-import-subprocess
 import subprocess  # nosec
+import sys
+from typing import Any
 
 # Third-Party Libraries
 import boto3
 
 # Inputs from Terraform
-NESSUS_AGENT_INSTALL_PATH = "${nessus_agent_install_path}"
-NESSUS_GROUPS = "${nessus_groups}"
-NESSUS_HOSTNAME_KEY = "${nessus_hostname_key}"
-NESSUS_KEY_KEY = "${nessus_key_key}"
-NESSUS_PORT_KEY = "${nessus_port_key}"
-SSM_READ_ROLE_ARN = "${ssm_read_role_arn}"
-SSM_REGION = "${ssm_region}"
+NESSUS_AGENT_INSTALL_PATH: str = "${nessus_agent_install_path}"
+NESSUS_GROUPS: str = "${nessus_groups}"
+NESSUS_HOSTNAME_KEY: str = "${nessus_hostname_key}"
+NESSUS_KEY_KEY: str = "${nessus_key_key}"
+NESSUS_PORT_KEY: str = "${nessus_port_key}"
+SSM_READ_ROLE_ARN: str = "${ssm_read_role_arn}"
+SSM_REGION: str = "${ssm_region}"
 
-# Create STS client
-sts_client = boto3.client("sts")
 
-# Assume the role that can read the SSM Parameter Store parameters
-stsresponse = sts_client.assume_role(
-    RoleArn=SSM_READ_ROLE_ARN, RoleSessionName="nessus_agent_linking"
-)
-newsession_id = stsresponse["Credentials"]["AccessKeyId"]
-newsession_key = stsresponse["Credentials"]["SecretAccessKey"]
-newsession_token = stsresponse["Credentials"]["SessionToken"]
+def get_parameter(ssm_client, parameter_name: str, with_decryption: bool = True) -> str:
+    """Get the value of the specified parameter."""
+    response: dict[str, Any] = ssm_client.get_parameter(
+        Name=parameter_name,
+        WithDecryption=with_decryption,
+    )
+    return response["Parameter"]["Value"]
 
-# Create a new client to access SSM Parameter Store using the
-# temporary credentials
-ssm_client = boto3.client(
-    "ssm",
-    aws_access_key_id=newsession_id,
-    aws_secret_access_key=newsession_key,
-    aws_session_token=newsession_token,
-    region_name=SSM_REGION,
-)
 
-# Get the values of the SSM Parameter Store parameters
-nessus_hostname_response = ssm_client.get_parameter(
-    Name=NESSUS_HOSTNAME_KEY,
-    WithDecryption=True,
-)
-nessus_hostname = nessus_hostname_response["Parameter"]["Value"]
+def main() -> int:
+    """Retrieve necessary values from SSM Parameter Store and link the Nessus Agent."""
+    # Create STS client
+    sts_client = boto3.client("sts")
 
-nessus_key_response = ssm_client.get_parameter(
-    Name=NESSUS_KEY_KEY,
-    WithDecryption=True,
-)
-nessus_key = nessus_key_response["Parameter"]["Value"]
+    # Assume the role that can read the SSM Parameter Store parameters
+    stsresponse: dict[str, Any] = sts_client.assume_role(
+        RoleArn=SSM_READ_ROLE_ARN, RoleSessionName="nessus_agent_linking"
+    )
+    newsession_id = stsresponse["Credentials"]["AccessKeyId"]
+    newsession_key = stsresponse["Credentials"]["SecretAccessKey"]
+    newsession_token = stsresponse["Credentials"]["SessionToken"]
 
-nessus_port_response = ssm_client.get_parameter(
-    Name=NESSUS_PORT_KEY,
-    WithDecryption=True,
-)
-nessus_port = nessus_port_response["Parameter"]["Value"]
+    # Create a new client to access SSM Parameter Store using the
+    # temporary credentials
+    ssm_client = boto3.client(
+        "ssm",
+        aws_access_key_id=newsession_id,
+        aws_secret_access_key=newsession_key,
+        aws_session_token=newsession_token,
+        region_name=SSM_REGION,
+    )
 
-# Link the Nessus Agent
-link_cmd = [
-    f"{NESSUS_AGENT_INSTALL_PATH}/sbin/nessuscli",
-    "agent",
-    "link",
-    f"--key={nessus_key}",
-    f"--host={nessus_hostname}",
-    f"--port={nessus_port}",
-    f"--groups={NESSUS_GROUPS}",
-]
-# Bandit triggers B603 here, but we're using subprocess.run() safely
-# here, since the variable content in link_cmd comes directly from SSM
-# Parameter Store.  For more details on B603 see here:
-# https://bandit.readthedocs.io/en/latest/plugins/b603_subprocess_without_shell_equals_true.html
-subprocess.run(link_cmd)  # nosec
+    # Get the values of the SSM Parameter Store parameters
+    nessus_hostname: str = get_parameter(ssm_client, NESSUS_HOSTNAME_KEY)
+    nessus_key: str = get_parameter(ssm_client, NESSUS_KEY_KEY)
+    nessus_port: str = get_parameter(ssm_client, NESSUS_PORT_KEY)
+
+    # Link the Nessus Agent
+    link_cmd: list[str] = [
+        f"{NESSUS_AGENT_INSTALL_PATH}/sbin/nessuscli",
+        "agent",
+        "link",
+        f"--key={nessus_key}",
+        f"--host={nessus_hostname}",
+        f"--port={nessus_port}",
+        f"--groups={NESSUS_GROUPS}",
+    ]
+    # Bandit triggers B603 here, but we're using subprocess.run()
+    # safely here, since the variable content in link_cmd comes
+    # directly from SSM Parameter Store.  For more details on B603 see
+    # here:
+    # https://bandit.readthedocs.io/en/latest/plugins/b603_subprocess_without_shell_equals_true.html
+    cp: subprocess.CompletedProcess = subprocess.run(link_cmd)  # nosec
+    return cp.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/cloud-init/link-nessus-agent.py
+++ b/cloud-init/link-nessus-agent.py
@@ -17,6 +17,7 @@ NESSUS_HOSTNAME_KEY = "${nessus_hostname_key}"
 NESSUS_KEY_KEY = "${nessus_key_key}"
 NESSUS_PORT_KEY = "${nessus_port_key}"
 SSM_READ_ROLE_ARN = "${ssm_read_role_arn}"
+SSM_REGION = "${ssm_region}"
 
 # Create STS client
 sts_client = boto3.client("sts")
@@ -36,6 +37,7 @@ ssm_client = boto3.client(
     aws_access_key_id=newsession_id,
     aws_secret_access_key=newsession_key,
     aws_session_token=newsession_token,
+    region_name=SSM_REGION,
 )
 
 # Get the values of the SSM Parameter Store parameters

--- a/cloud-init/link-nessus-agent.py
+++ b/cloud-init/link-nessus-agent.py
@@ -5,6 +5,8 @@
 This file is a template.  It must be processed by Terraform.
 """
 
+from __future__ import annotations
+
 # Standard Python Libraries
 # Bandit triggers B404 here, but we're only using subprocess.run() and
 # doing so safely.  For more details on B404 see here:

--- a/cloud-init/link-nessus-agent.py
+++ b/cloud-init/link-nessus-agent.py
@@ -15,6 +15,7 @@ import subprocess  # nosec
 import boto3
 
 # Inputs from Terraform
+NESSUS_AGENT_INSTALL_PATH = "${nessus_agent_install_path}"
 NESSUS_GROUPS = "${nessus_groups}"
 NESSUS_HOSTNAME_KEY = "${nessus_hostname_key}"
 NESSUS_KEY_KEY = "${nessus_key_key}"
@@ -64,7 +65,7 @@ nessus_port = nessus_port_response["Parameter"]["Value"]
 
 # Link the Nessus Agent
 link_cmd = [
-    "/opt/nessus_agent/sbin/nessuscli",
+    f"{NESSUS_AGENT_INSTALL_PATH}/sbin/nessuscli",
     "agent",
     "link",
     f"--key={nessus_key}",

--- a/cloud-init/link-nessus-agent.py
+++ b/cloud-init/link-nessus-agent.py
@@ -45,19 +45,19 @@ nessus_hostname_response = ssm_client.get_parameter(
     Name=NESSUS_HOSTNAME_KEY,
     WithDecryption=True,
 )
-nessus_hostname = nessus_hostname_response["Value"]
+nessus_hostname = nessus_hostname_response["Parameter"]["Value"]
 
 nessus_key_response = ssm_client.get_parameter(
     Name=NESSUS_KEY_KEY,
     WithDecryption=True,
 )
-nessus_key = nessus_key_response["Value"]
+nessus_key = nessus_key_response["Parameter"]["Value"]
 
 nessus_port_response = ssm_client.get_parameter(
     Name=NESSUS_PORT_KEY,
     WithDecryption=True,
 )
-nessus_port = nessus_port_response["Value"]
+nessus_port = nessus_port_response["Parameter"]["Value"]
 
 # Link the Nessus Agent
 link_cmd = [

--- a/cloud-init/link-nessus-agent.py
+++ b/cloud-init/link-nessus-agent.py
@@ -14,7 +14,7 @@ import subprocess  # nosec
 # Third-Party Libraries
 import boto3
 
-# Inputs from terraform
+# Inputs from Terraform
 NESSUS_GROUPS = "${nessus_groups}"
 NESSUS_HOSTNAME_KEY = "${nessus_hostname_key}"
 NESSUS_KEY_KEY = "${nessus_key_key}"

--- a/cloud_init.tf
+++ b/cloud_init.tf
@@ -1,3 +1,9 @@
+# This is used to extract the region where the IPA instance is being
+# created
+data "aws_arn" "subnet" {
+  arn = data.aws_subnet.the_subnet.arn
+}
+
 data "cloudinit_config" "configure_freeipa" {
   gzip          = true
   base64_encode = true
@@ -40,6 +46,8 @@ data "cloudinit_config" "configure_freeipa" {
         nessus_key_key      = var.nessus_key_key
         nessus_port_key     = var.nessus_port_key
         ssm_read_role_arn   = module.read_ssm_parameters.role.arn
+        # This is the region where the IPA instance is being created
+        ssm_region = data.aws_arn.subnet.region
     })
   }
 }

--- a/cloud_init.tf
+++ b/cloud_init.tf
@@ -41,11 +41,12 @@ data "cloudinit_config" "configure_freeipa" {
     content_type = "text/x-shellscript"
     content = templatefile(
       "${path.module}/cloud-init/link-nessus-agent.py", {
-        nessus_groups       = join(",", var.nessus_groups)
-        nessus_hostname_key = var.nessus_hostname_key
-        nessus_key_key      = var.nessus_key_key
-        nessus_port_key     = var.nessus_port_key
-        ssm_read_role_arn   = module.read_ssm_parameters.role.arn
+        nessus_agent_install_path = var.nessus_agent_install_path
+        nessus_groups             = join(",", var.nessus_groups)
+        nessus_hostname_key       = var.nessus_hostname_key
+        nessus_key_key            = var.nessus_key_key
+        nessus_port_key           = var.nessus_port_key
+        ssm_read_role_arn         = module.read_ssm_parameters.role.arn
         # This is the region where the IPA instance is being created
         ssm_region = data.aws_arn.subnet.region
     })

--- a/cloud_init.tf
+++ b/cloud_init.tf
@@ -39,6 +39,7 @@ data "cloudinit_config" "configure_freeipa" {
         nessus_hostname_key = var.nessus_hostname_key
         nessus_key_key      = var.nessus_key_key
         nessus_port_key     = var.nessus_port_key
+        ssm_read_role_arn   = module.read_ssm_parameters.role.arn
     })
   }
 }

--- a/cloud_init.tf
+++ b/cloud_init.tf
@@ -35,7 +35,7 @@ data "cloudinit_config" "configure_freeipa" {
     content_type = "text/x-shellscript"
     content = templatefile(
       "${path.module}/cloud-init/link-nessus-agent.py", {
-        nessus_groups       = var.nessus_groups
+        nessus_groups       = join(",", var.nessus_groups)
         nessus_hostname_key = var.nessus_hostname_key
         nessus_key_key      = var.nessus_key_key
         nessus_port_key     = var.nessus_port_key

--- a/cloud_init.tf
+++ b/cloud_init.tf
@@ -25,4 +25,20 @@ data "cloudinit_config" "configure_freeipa" {
     })
     merge_type = "list(append)+dict(recurse_array)+str()"
   }
+
+  # Note: The filename parameters in each part below are used to name
+  # the mime-parts of the user-data as well as the filename in the
+  # scripts directory.
+
+  part {
+    filename     = "link-nessus-agent.py"
+    content_type = "text/x-shellscript"
+    content = templatefile(
+      "${path.module}/cloud-init/link-nessus-agent.py", {
+        nessus_groups       = var.nessus_groups
+        nessus_hostname_key = var.nessus_hostname_key
+        nessus_key_key      = var.nessus_key_key
+        nessus_port_key     = var.nessus_port_key
+    })
+  }
 }

--- a/examples/basic_usage/README.md
+++ b/examples/basic_usage/README.md
@@ -18,12 +18,28 @@ No requirements.
 |------|---------|
 | aws | n/a |
 
+## Modules ##
+
+| Name | Source | Version |
+|------|--------|---------|
+| ipa | ../../ |  |
+
+## Resources ##
+
+| Name | Type |
+|------|------|
+| [aws_default_route_table.the_route_table](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_route_table) | resource |
+| [aws_internet_gateway.the_igw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/internet_gateway) | resource |
+| [aws_route.route_external_traffic_through_internet_gateway](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
+| [aws_subnet.subnet](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
+| [aws_vpc.the_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) | resource |
+
 ## Inputs ##
 
-No input.
+No inputs.
 
 ## Outputs ##
 
 | Name | Description |
 |------|-------------|
-| ipa_server | The IPA server EC2 instance. |
+| ipa\_server | The IPA server EC2 instance. |

--- a/examples/basic_usage/main.tf
+++ b/examples/basic_usage/main.tf
@@ -3,6 +3,12 @@ provider "aws" {
   region  = "us-east-1"
 }
 
+provider "aws" {
+  alias   = "provision_ssm_parameter_read_role"
+  profile = "cool-images-provisionparameterstorereadroles"
+  region  = "us-east-1"
+}
+
 #-------------------------------------------------------------------------------
 # Create a subnet inside a VPC.
 #-------------------------------------------------------------------------------
@@ -43,11 +49,18 @@ resource "aws_route" "route_external_traffic_through_internet_gateway" {
 #-------------------------------------------------------------------------------
 module "ipa" {
   source = "../../"
+  providers = {
+    aws                                   = aws
+    aws.provision_ssm_parameter_read_role = aws.provision_ssm_parameter_read_role
+  }
 
   ami_owner_account_id = "207871073513" # The COOL Images account
   domain               = "cal23.cyber.dhs.gov"
   hostname             = "ipa.cal23.cyber.dhs.gov"
   ip                   = "10.99.48.4"
+  nessus_hostname_key  = "/cdm/nessus_hostname"
+  nessus_key_key       = "/cdm/nessus_key"
+  nessus_port_key      = "/cdm/nessus_port"
   realm                = "CAL23.CYBER.DHS.GOV"
   subnet_id            = aws_subnet.subnet.id
   tags = {

--- a/instance_role.tf
+++ b/instance_role.tf
@@ -7,6 +7,9 @@ module "read_ssm_parameters" {
     aws = aws.provision_ssm_parameter_read_role
   }
 
+  # Allow the account where the instance is being created to assume
+  # this role, which lives in the Images account.
+  account_ids = [data.aws_caller_identity.main.account_id]
   entity_name = var.hostname
   ssm_names = [
     var.nessus_hostname_key,

--- a/providers.tf
+++ b/providers.tf
@@ -1,0 +1,11 @@
+# This is the "default" provider that is used to obtain the caller's
+# credentials, which are used to set the session name when assuming
+# roles in the other providers.
+provider "aws" {
+}
+
+# The provider used to create IAM roles that can read selected SSM
+# ParameterStore parameters in the Images account.
+provider "aws" {
+  alias = "provision_ssm_parameter_read_role"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -43,6 +43,30 @@ variable "aws_instance_type" {
   default     = "t3.medium"
 }
 
+variable "nessus_groups" {
+  type        = list(string)
+  description = "A list of strings, each of which is the name of a group in the CDM Tenable Nessus server that the Nessus Agent should join (e.g. [\"group1\", \"group2\"])."
+  default     = ["COOL_Fed_32"]
+}
+
+variable "nessus_hostname_key" {
+  type        = string
+  description = "The SSM Parameter Store key whose corresponding value contains the hostname of the CDM Tenable Nessus server to which the Nessus Agent should link (e.g. /cdm/nessus_hostname)."
+  default     = "/cdm/nessus_hostname"
+}
+
+variable "nessus_key_key" {
+  type        = string
+  description = "The SSM Parameter Store key whose corresponding value contains the secret key that the Nessus Agent should use when linking with the CDM Tenable Nessus server (e.g. /cdm/nessus_key)."
+  default     = "/cdm/nessus_key"
+}
+
+variable "nessus_port_key" {
+  type        = string
+  description = "The SSM Parameter Store key whose corresponding value contains the port to which the Nessus Agent should connect when linking with the CDM Tenable Nessus server (e.g. /cdm/nessus_port)."
+  default     = "/cdm/nessus_port"
+}
+
 variable "realm" {
   type        = string
   description = "The realm for the IPA server (e.g. EXAMPLE.COM).  Only used if this IPA server IS NOT intended to be a replica."

--- a/variables.tf
+++ b/variables.tf
@@ -19,6 +19,21 @@ variable "ip" {
   description = "The IP address to assign the IPA server (e.g. 10.10.10.4).  Note that the IP address must be contained inside the CIDR block corresponding to subnet-id, and AWS reserves the first four and very last IP addresses.  We have to assign an IP in order to break the dependency of DNS record resources on the corresponding EC2 resources; otherwise, it is impossible to update the IPA servers one by one as is required when a new AMI is created."
 }
 
+variable "nessus_hostname_key" {
+  type        = string
+  description = "The SSM Parameter Store key whose corresponding value contains the hostname of the CDM Tenable Nessus server to which the Nessus Agent should link (e.g. /cdm/nessus/hostname)."
+}
+
+variable "nessus_key_key" {
+  type        = string
+  description = "The SSM Parameter Store key whose corresponding value contains the secret key that the Nessus Agent should use when linking with the CDM Tenable Nessus server (e.g. /cdm/nessus/key)."
+}
+
+variable "nessus_port_key" {
+  type        = string
+  description = "The SSM Parameter Store key whose corresponding value contains the port to which the Nessus Agent should connect when linking with the CDM Tenable Nessus server (e.g. /cdm/nessus/port)."
+}
+
 variable "subnet_id" {
   type        = string
   description = "The ID of the AWS subnet into which to deploy the IPA server (e.g. subnet-0123456789abcdef0)."
@@ -53,24 +68,6 @@ variable "nessus_groups" {
   type        = list(string)
   description = "A list of strings, each of which is the name of a group in the CDM Tenable Nessus server that the Nessus Agent should join (e.g. [\"group1\", \"group2\"])."
   default     = ["COOL_Fed_32"]
-}
-
-variable "nessus_hostname_key" {
-  type        = string
-  description = "The SSM Parameter Store key whose corresponding value contains the hostname of the CDM Tenable Nessus server to which the Nessus Agent should link (e.g. /cdm/nessus_hostname)."
-  default     = "/cdm/nessus_hostname"
-}
-
-variable "nessus_key_key" {
-  type        = string
-  description = "The SSM Parameter Store key whose corresponding value contains the secret key that the Nessus Agent should use when linking with the CDM Tenable Nessus server (e.g. /cdm/nessus_key)."
-  default     = "/cdm/nessus_key"
-}
-
-variable "nessus_port_key" {
-  type        = string
-  description = "The SSM Parameter Store key whose corresponding value contains the port to which the Nessus Agent should connect when linking with the CDM Tenable Nessus server (e.g. /cdm/nessus_port)."
-  default     = "/cdm/nessus_port"
 }
 
 variable "realm" {

--- a/variables.tf
+++ b/variables.tf
@@ -43,6 +43,12 @@ variable "aws_instance_type" {
   default     = "t3.medium"
 }
 
+variable "nessus_agent_install_path" {
+  type        = string
+  description = "The install path of Nessus Agent (e.g. /opt/nessus_agent)."
+  default     = "/opt/nessus_agent"
+}
+
 variable "nessus_groups" {
   type        = list(string)
   description = "A list of strings, each of which is the name of a group in the CDM Tenable Nessus server that the Nessus Agent should join (e.g. [\"group1\", \"group2\"])."


### PR DESCRIPTION
## 🗣 Description ##

This pull request makes the necessary changes to link the Nessus Agent to the CDM Tenable/Nessus server via [`cloud-init`](https://cloud-init.io/) at first boot.

## 💭 Motivation and context ##

We must move the configuration of the Nessus Agent link from [cisagov/ansible-role-cdm-nessus-agent](https://github.com/cisagov/ansible-role-cdm-nessus-agent) to here.  This is because the linking command generates a Tenable Tag, which uniquely identifies the instance to the CDM Nessus server.  If we perform this step at AMI build time, then all instances created from that AMI will have identical Tenable Tags.  Nessus cannot handle "duplicated agents" like this, so we need to instead perform the linking via `cloud-init` at first boot.

See also:
* cisagov/ansible-role-cdm-nessus-agent#11
* cisagov/freeipa-server-packer#51
* cisagov/cool-sharedservices-freeipa#36

## 🧪 Testing ##

All `pre-commit` hooks pass.  I have also deployed these changes to our staging COOL environment and verified that they function as intended.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
* [x] All new and existing tests pass.
