### PR TITLE
Allow specification of the instance's root disk size

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ module "ipa1" {
 | nessus\_key\_key | The SSM Parameter Store key whose corresponding value contains the secret key that the Nessus Agent should use when linking with the CDM Tenable Nessus server (e.g. /cdm/nessus/key). | `string` | n/a | yes |
 | nessus\_port\_key | The SSM Parameter Store key whose corresponding value contains the port to which the Nessus Agent should connect when linking with the CDM Tenable Nessus server (e.g. /cdm/nessus/port). | `string` | n/a | yes |
 | realm | The realm for the IPA server (e.g. EXAMPLE.COM).  Only used if this IPA server IS NOT intended to be a replica. | `string` | `"EXAMPLE.COM"` | no |
+| root\_disk\_size | The size of the IPA instance's root disk in GB. | `number` | `8` | no |
 | security\_group\_ids | A list of IDs corresponding to security groups to which the server should belong (e.g. ["sg-51530134", "sg-51530245"]).  Note that these security groups must exist in the same VPC as the server. | `list(string)` | `[]` | no |
 | subnet\_id | The ID of the AWS subnet into which to deploy the IPA server (e.g. subnet-0123456789abcdef0). | `string` | n/a | yes |
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ module "ipa1" {
 | nessus\_key\_key | The SSM Parameter Store key whose corresponding value contains the secret key that the Nessus Agent should use when linking with the CDM Tenable Nessus server (e.g. /cdm/nessus/key). | `string` | n/a | yes |
 | nessus\_port\_key | The SSM Parameter Store key whose corresponding value contains the port to which the Nessus Agent should connect when linking with the CDM Tenable Nessus server (e.g. /cdm/nessus/port). | `string` | n/a | yes |
 | realm | The realm for the IPA server (e.g. EXAMPLE.COM).  Only used if this IPA server IS NOT intended to be a replica. | `string` | `"EXAMPLE.COM"` | no |
-| root\_disk\_size | The size of the IPA instance's root disk in GB. | `number` | `8` | no |
+| root\_disk\_size | The size of the IPA instance's root disk in GiB. | `number` | `8` | no |
 | security\_group\_ids | A list of IDs corresponding to security groups to which the server should belong (e.g. ["sg-51530134", "sg-51530245"]).  Note that these security groups must exist in the same VPC as the server. | `list(string)` | `[]` | no |
 | subnet\_id | The ID of the AWS subnet into which to deploy the IPA server (e.g. subnet-0123456789abcdef0). | `string` | n/a | yes |
 

--- a/ec2.tf
+++ b/ec2.tf
@@ -12,6 +12,9 @@ resource "aws_instance" "ipa" {
   vpc_security_group_ids      = var.security_group_ids
   user_data_base64            = data.cloudinit_config.configure_freeipa.rendered
   iam_instance_profile        = aws_iam_instance_profile.ipa.name
+  root_block_device {
+    volume_size = var.root_disk_size
+  }
   # AWS Instance Meta-Data Service (IMDS) options
   metadata_options {
     # Enable IMDS (this is the default value)

--- a/variables.tf
+++ b/variables.tf
@@ -76,6 +76,12 @@ variable "realm" {
   default     = "EXAMPLE.COM"
 }
 
+variable "root_disk_size" {
+  type        = number
+  description = "The size of the IPA instance's root disk in GB."
+  default     = 8
+}
+
 variable "security_group_ids" {
   type        = list(string)
   description = "A list of IDs corresponding to security groups to which the server should belong (e.g. [\"sg-51530134\", \"sg-51530245\"]).  Note that these security groups must exist in the same VPC as the server."

--- a/variables.tf
+++ b/variables.tf
@@ -78,7 +78,7 @@ variable "realm" {
 
 variable "root_disk_size" {
   type        = number
-  description = "The size of the IPA instance's root disk in GB."
+  description = "The size of the IPA instance's root disk in GiB."
   default     = 8
 }
 


### PR DESCRIPTION
## 🗣 Description ##

This pull requests adds an optional input variable specifying the size of the FreeIPA instance's root disk in GB.  The new variable is optional, so it will not break existing code.

See also cisagov/cool-sharedservices-freeipa#42.

## 💭 Motivation and context ##

In some cases it makes sense to have more space than the 8GB size of the AMI.

## 🧪 Testing ##

I have successfully applied these changes to our production COOL environment.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.
