### PR TITLE
Upgrade the root volume type to gp3

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -14,6 +14,7 @@ resource "aws_instance" "ipa" {
   iam_instance_profile        = aws_iam_instance_profile.ipa.name
   root_block_device {
     volume_size = var.root_disk_size
+    volume_type = "gp3"
   }
   # AWS Instance Meta-Data Service (IMDS) options
   metadata_options {


### PR DESCRIPTION
## 🗣 Description ##

This pull request upgrades teh root volume type to gp3.

## 💭 Motivation and context ##

gp3 is 20% cheaper, and the baseline configuration offers better performance than gp2 for volumes smaller than 2TB.  It also allows the volume size and IOPS to be configured separately, whereas the two are intertwined with gp2.

## 🧪 Testing ##

See cisagov/cool-assessment-terraform#148 for an example of how I tested identical changes in another repository.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
