### PR TITLE
Add NETBIOS name to the FreeIPA variables shell script

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ module "ipa0" {
   nessus_hostname_key = "/thulsa/doom/nessus/hostname"
   nessus_key_key      = "/thulsa/doom/nessus/key"
   nessus_port_key     = "/thulsa/doom/nessus/port"
+  netbios_name        = "EXAMPLE"
   realm               = "EXAMPLE.COM"
   security_group_ids  = ["sg-51530134", "sg-51530245"]
   subnet_id           = aws_subnet.first_subnet.id
@@ -30,6 +31,7 @@ module "ipa1" {
   nessus_hostname_key = "/thulsa/doom/nessus/hostname"
   nessus_key_key      = "/thulsa/doom/nessus/key"
   nessus_port_key     = "/thulsa/doom/nessus/port"
+  netbios_name        = "EXAMPLE"
   security_group_ids  = ["sg-51530134", "sg-51530245"]
   subnet_id           = aws_subnet.second_subnet.id
 }
@@ -94,6 +96,7 @@ module "ipa1" {
 | nessus\_hostname\_key | The SSM Parameter Store key whose corresponding value contains the hostname of the CDM Tenable Nessus server to which the Nessus Agent should link (e.g. /cdm/nessus/hostname). | `string` | n/a | yes |
 | nessus\_key\_key | The SSM Parameter Store key whose corresponding value contains the secret key that the Nessus Agent should use when linking with the CDM Tenable Nessus server (e.g. /cdm/nessus/key). | `string` | n/a | yes |
 | nessus\_port\_key | The SSM Parameter Store key whose corresponding value contains the port to which the Nessus Agent should connect when linking with the CDM Tenable Nessus server (e.g. /cdm/nessus/port). | `string` | n/a | yes |
+| netbios\_name | The NETBIOS name to be used by the server (e.g. EXAMPLE).  Note that NETBIOS names are restricted to at most 15 characters.  These characters must consist only of uppercase letters, numbers, and dashes. | `string` | n/a | yes |
 | realm | The realm for the IPA server (e.g. EXAMPLE.COM).  Only used if this IPA server IS NOT intended to be a replica. | `string` | `"EXAMPLE.COM"` | no |
 | root\_disk\_size | The size of the IPA instance's root disk in GiB. | `number` | `8` | no |
 | security\_group\_ids | A list of IDs corresponding to security groups to which the server should belong (e.g. ["sg-51530134", "sg-51530245"]).  Note that these security groups must exist in the same VPC as the server. | `list(string)` | `[]` | no |

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ module "ipa1" {
 | nessus\_hostname\_key | The SSM Parameter Store key whose corresponding value contains the hostname of the CDM Tenable Nessus server to which the Nessus Agent should link (e.g. /cdm/nessus/hostname). | `string` | n/a | yes |
 | nessus\_key\_key | The SSM Parameter Store key whose corresponding value contains the secret key that the Nessus Agent should use when linking with the CDM Tenable Nessus server (e.g. /cdm/nessus/key). | `string` | n/a | yes |
 | nessus\_port\_key | The SSM Parameter Store key whose corresponding value contains the port to which the Nessus Agent should connect when linking with the CDM Tenable Nessus server (e.g. /cdm/nessus/port). | `string` | n/a | yes |
-| netbios\_name | The NETBIOS name to be used by the server (e.g. EXAMPLE).  Note that NETBIOS names are restricted to at most 15 characters.  These characters must consist only of uppercase letters, numbers, and dashes. | `string` | n/a | yes |
+| netbios\_name | The NetBIOS name to be used by the server (e.g. EXAMPLE).  Note that NetBIOS names are restricted to at most 15 characters.  These characters must consist only of uppercase letters, numbers, and dashes. | `string` | n/a | yes |
 | realm | The realm for the IPA server (e.g. EXAMPLE.COM).  Only used if this IPA server IS NOT intended to be a replica. | `string` | `"EXAMPLE.COM"` | no |
 | root\_disk\_size | The size of the IPA instance's root disk in GiB. | `number` | `8` | no |
 | security\_group\_ids | A list of IDs corresponding to security groups to which the server should belong (e.g. ["sg-51530134", "sg-51530245"]).  Note that these security groups must exist in the same VPC as the server. | `list(string)` | `[]` | no |

--- a/cloud-init/freeipa-vars.tpl.yml
+++ b/cloud-init/freeipa-vars.tpl.yml
@@ -6,4 +6,5 @@ write_files:
     content: |
       domain=${domain}
       hostname=${hostname}
+      netbios_name=${netbios_name}
       realm=${realm}

--- a/cloud_init.tf
+++ b/cloud_init.tf
@@ -25,9 +25,10 @@ data "cloudinit_config" "configure_freeipa" {
     content_type = "text/cloud-config"
     content = templatefile(
       "${path.module}/cloud-init/freeipa-vars.tpl.yml", {
-        domain   = var.domain
-        hostname = var.hostname
-        realm    = var.realm
+        domain       = var.domain
+        hostname     = var.hostname
+        netbios_name = var.netbios_name
+        realm        = var.realm
     })
     merge_type = "list(append)+dict(recurse_array)+str()"
   }

--- a/examples/basic_usage/main.tf
+++ b/examples/basic_usage/main.tf
@@ -74,6 +74,7 @@ module "ipa" {
   nessus_hostname_key  = "/cdm/nessus_hostname"
   nessus_key_key       = "/cdm/nessus_key"
   nessus_port_key      = "/cdm/nessus_port"
+  netbios_name         = "CAL23"
   realm                = "CAL23.CYBER.DHS.GOV"
   subnet_id            = aws_subnet.subnet.id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -36,10 +36,10 @@ variable "nessus_port_key" {
 
 variable "netbios_name" {
   type        = string
-  description = "The NETBIOS name to be used by the server (e.g. EXAMPLE).  Note that NETBIOS names are restricted to at most 15 characters.  These characters must consist only of uppercase letters, numbers, and dashes."
+  description = "The NetBIOS name to be used by the server (e.g. EXAMPLE).  Note that NetBIOS names are restricted to at most 15 characters.  These characters must consist only of uppercase letters, numbers, and dashes."
   validation {
     condition     = length(var.netbios_name) <= 15 && length(regexall("[^A-Z0-9-]", var.netbios_name)) == 0
-    error_message = "NETBIOS names are restricted to at most 15 characters.  These characters must consist only of uppercase letters, numbers, and dashes."
+    error_message = "NetBIOS names are restricted to at most 15 characters.  These characters must consist only of uppercase letters, numbers, and dashes."
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -34,6 +34,15 @@ variable "nessus_port_key" {
   description = "The SSM Parameter Store key whose corresponding value contains the port to which the Nessus Agent should connect when linking with the CDM Tenable Nessus server (e.g. /cdm/nessus/port)."
 }
 
+variable "netbios_name" {
+  type        = string
+  description = "The NETBIOS name to be used by the server (e.g. EXAMPLE).  Note that NETBIOS names are restricted to at most 15 characters.  These characters must consist only of uppercase letters, numbers, and dashes."
+  validation {
+    condition     = length(var.netbios_name) <= 15 && length(regexall("[^A-Z0-9-]", var.netbios_name)) == 0
+    error_message = "NETBIOS names are restricted to at most 15 characters.  These characters must consist only of uppercase letters, numbers, and dashes."
+  }
+}
+
 variable "subnet_id" {
   type        = string
   description = "The ID of the AWS subnet into which to deploy the IPA server (e.g. subnet-0123456789abcdef0)."


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds the NETBIOS name to the FreeIPA variables shell script.

## 💭 Motivation and context ##

This input parameter is now required by `ipa-replica-install` and `ipa-server-install`, even though it isn't used in our case.

See also:
- cisagov/ansible-role-freeipa-server#47
- cisagov/cool-sharedservices-freeipa#46

## 🧪 Testing ##

Automated testing passes.  I also used this code to deploy a new staging AMI and verified that it functions as expected.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.