### PR TITLE
Add load balancer hostname as input variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,30 +10,32 @@ A Terraform module for deploying a FreeIPA server.
 module "ipa0" {
   source = "github.com/cisagov/freeipa-server-tf-module"
 
-  domain              = "example.com"
-  hostname            = "ipa0.example.com"
-  ip                  = "10.10.10.4"
-  nessus_hostname_key = "/thulsa/doom/nessus/hostname"
-  nessus_key_key      = "/thulsa/doom/nessus/key"
-  nessus_port_key     = "/thulsa/doom/nessus/port"
-  netbios_name        = "EXAMPLE"
-  realm               = "EXAMPLE.COM"
-  security_group_ids  = ["sg-51530134", "sg-51530245"]
-  subnet_id           = aws_subnet.first_subnet.id
+  domain                 = "example.com"
+  hostname               = "ipa0.example.com"
+  ip                     = "10.10.10.4"
+  load_balancer_hostname = "ipa.example.com"
+  nessus_hostname_key    = "/thulsa/doom/nessus/hostname"
+  nessus_key_key         = "/thulsa/doom/nessus/key"
+  nessus_port_key        = "/thulsa/doom/nessus/port"
+  netbios_name           = "EXAMPLE"
+  realm                  = "EXAMPLE.COM"
+  security_group_ids     = ["sg-51530134", "sg-51530245"]
+  subnet_id              = aws_subnet.first_subnet.id
 }
 
 module "ipa1" {
   source = "github.com/cisagov/freeipa-server-tf-module"
 
-  domain              = "example.com"
-  hostname            = "ipa1.example.com"
-  ip                  = "10.10.10.5"
-  nessus_hostname_key = "/thulsa/doom/nessus/hostname"
-  nessus_key_key      = "/thulsa/doom/nessus/key"
-  nessus_port_key     = "/thulsa/doom/nessus/port"
-  netbios_name        = "EXAMPLE"
-  security_group_ids  = ["sg-51530134", "sg-51530245"]
-  subnet_id           = aws_subnet.second_subnet.id
+  domain                 = "example.com"
+  hostname               = "ipa1.example.com"
+  ip                     = "10.10.10.5"
+  load_balancer_hostname = "ipa.example.com"
+  nessus_hostname_key    = "/thulsa/doom/nessus/hostname"
+  nessus_key_key         = "/thulsa/doom/nessus/key"
+  nessus_port_key        = "/thulsa/doom/nessus/port"
+  netbios_name           = "EXAMPLE"
+  security_group_ids     = ["sg-51530134", "sg-51530245"]
+  subnet_id              = aws_subnet.second_subnet.id
 }
 ```
 
@@ -91,6 +93,7 @@ module "ipa1" {
 | domain | The domain for the IPA server (e.g. example.com). | `string` | n/a | yes |
 | hostname | The hostname of the IPA server (e.g. ipa.example.com). | `string` | n/a | yes |
 | ip | The IP address to assign the IPA server (e.g. 10.10.10.4).  Note that the IP address must be contained inside the CIDR block corresponding to subnet-id, and AWS reserves the first four and very last IP addresses.  We have to assign an IP in order to break the dependency of DNS record resources on the corresponding EC2 resources; otherwise, it is impossible to update the IPA servers one by one as is required when a new AMI is created. | `string` | n/a | yes |
+| load\_balancer\_hostname | The hostname of the AWS load balancer in front of the FreeIPA cluster (e.g. ipa.example.com). | `string` | n/a | yes |
 | nessus\_agent\_install\_path | The install path of Nessus Agent (e.g. /opt/nessus\_agent). | `string` | `"/opt/nessus_agent"` | no |
 | nessus\_groups | A list of strings, each of which is the name of a group in the CDM Tenable Nessus server that the Nessus Agent should join (e.g. ["group1", "group2"]). | `list(string)` | ```[ "COOL_Fed_32" ]``` | no |
 | nessus\_hostname\_key | The SSM Parameter Store key whose corresponding value contains the hostname of the CDM Tenable Nessus server to which the Nessus Agent should link (e.g. /cdm/nessus/hostname). | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ module "ipa1" {
 | ami\_owner\_account\_id | The ID of the AWS account that owns the FreeIPA server AMI, or "self" if the AMI is owned by the same account as the provisioner. | `string` | `"self"` | no |
 | aws\_instance\_type | The AWS instance type to deploy (e.g. t3.medium).  Two gigabytes of RAM is given as a minimum requirement for FreeIPA, but I have had intermittent problems when creating t3.small replicas. | `string` | `"t3.medium"` | no |
 | domain | The domain for the IPA server (e.g. example.com). | `string` | n/a | yes |
-| hostname | The hostname of the IPA server (e.g. ipa.example.com). | `string` | n/a | yes |
+| hostname | The hostname of the IPA server (e.g. ipa0.example.com). | `string` | n/a | yes |
 | ip | The IP address to assign the IPA server (e.g. 10.10.10.4).  Note that the IP address must be contained inside the CIDR block corresponding to subnet-id, and AWS reserves the first four and very last IP addresses.  We have to assign an IP in order to break the dependency of DNS record resources on the corresponding EC2 resources; otherwise, it is impossible to update the IPA servers one by one as is required when a new AMI is created. | `string` | n/a | yes |
 | load\_balancer\_hostname | The hostname of the AWS load balancer in front of the FreeIPA cluster (e.g. ipa.example.com). | `string` | n/a | yes |
 | nessus\_agent\_install\_path | The install path of Nessus Agent (e.g. /opt/nessus\_agent). | `string` | `"/opt/nessus_agent"` | no |

--- a/README.md
+++ b/README.md
@@ -91,9 +91,9 @@ module "ipa1" {
 | ami\_owner\_account\_id | The ID of the AWS account that owns the FreeIPA server AMI, or "self" if the AMI is owned by the same account as the provisioner. | `string` | `"self"` | no |
 | aws\_instance\_type | The AWS instance type to deploy (e.g. t3.medium).  Two gigabytes of RAM is given as a minimum requirement for FreeIPA, but I have had intermittent problems when creating t3.small replicas. | `string` | `"t3.medium"` | no |
 | domain | The domain for the IPA server (e.g. example.com). | `string` | n/a | yes |
-| hostname | The hostname of the IPA server (e.g. ipa0.example.com). | `string` | n/a | yes |
+| fqdn | The FQDN of the IPA server (e.g. ipa0.example.com). | `string` | n/a | yes |
 | ip | The IP address to assign the IPA server (e.g. 10.10.10.4).  Note that the IP address must be contained inside the CIDR block corresponding to subnet-id, and AWS reserves the first four and very last IP addresses.  We have to assign an IP in order to break the dependency of DNS record resources on the corresponding EC2 resources; otherwise, it is impossible to update the IPA servers one by one as is required when a new AMI is created. | `string` | n/a | yes |
-| load\_balancer\_hostname | The hostname of the AWS load balancer in front of the FreeIPA cluster (e.g. ipa.example.com). | `string` | n/a | yes |
+| load\_balancer\_fqdn | The FQDN of the AWS load balancer in front of the FreeIPA cluster (e.g. ipa.example.com). | `string` | n/a | yes |
 | nessus\_agent\_install\_path | The install path of Nessus Agent (e.g. /opt/nessus\_agent). | `string` | `"/opt/nessus_agent"` | no |
 | nessus\_groups | A list of strings, each of which is the name of a group in the CDM Tenable Nessus server that the Nessus Agent should join (e.g. ["group1", "group2"]). | `list(string)` | ```[ "COOL_Fed_32" ]``` | no |
 | nessus\_hostname\_key | The SSM Parameter Store key whose corresponding value contains the hostname of the CDM Tenable Nessus server to which the Nessus Agent should link (e.g. /cdm/nessus/hostname). | `string` | n/a | yes |

--- a/cloud-init/freeipa-vars.tpl.yml
+++ b/cloud-init/freeipa-vars.tpl.yml
@@ -6,5 +6,6 @@ write_files:
     content: |
       domain=${domain}
       hostname=${hostname}
+      load_balancer_hostname=${load_balancer_hostname}
       netbios_name=${netbios_name}
       realm=${realm}

--- a/cloud-init/freeipa-vars.tpl.yml
+++ b/cloud-init/freeipa-vars.tpl.yml
@@ -5,7 +5,7 @@ write_files:
     owner: root:root
     content: |
       domain=${domain}
-      hostname=${hostname}
-      load_balancer_hostname=${load_balancer_hostname}
+      fqdn=${fqdn}
+      load_balancer_fqdn=${load_balancer_fqdn}
       netbios_name=${netbios_name}
       realm=${realm}

--- a/cloud_init.tf
+++ b/cloud_init.tf
@@ -25,10 +25,11 @@ data "cloudinit_config" "configure_freeipa" {
     content_type = "text/cloud-config"
     content = templatefile(
       "${path.module}/cloud-init/freeipa-vars.tpl.yml", {
-        domain       = var.domain
-        hostname     = var.hostname
-        netbios_name = var.netbios_name
-        realm        = var.realm
+        domain                 = var.domain
+        hostname               = var.hostname
+        load_balancer_hostname = var.load_balancer_hostname
+        netbios_name           = var.netbios_name
+        realm                  = var.realm
     })
     merge_type = "list(append)+dict(recurse_array)+str()"
   }

--- a/cloud_init.tf
+++ b/cloud_init.tf
@@ -25,11 +25,11 @@ data "cloudinit_config" "configure_freeipa" {
     content_type = "text/cloud-config"
     content = templatefile(
       "${path.module}/cloud-init/freeipa-vars.tpl.yml", {
-        domain                 = var.domain
-        hostname               = var.hostname
-        load_balancer_hostname = var.load_balancer_hostname
-        netbios_name           = var.netbios_name
-        realm                  = var.realm
+        domain             = var.domain
+        fqdn               = var.fqdn
+        load_balancer_fqdn = var.load_balancer_fqdn
+        netbios_name       = var.netbios_name
+        realm              = var.realm
     })
     merge_type = "list(append)+dict(recurse_array)+str()"
   }

--- a/examples/basic_usage/main.tf
+++ b/examples/basic_usage/main.tf
@@ -67,15 +67,15 @@ module "ipa" {
     aws.provision_ssm_parameter_read_role = aws.provision_ssm_parameter_read_role
   }
 
-  ami_owner_account_id   = "207871073513" # The COOL Images account
-  domain                 = "cal23.cyber.dhs.gov"
-  hostname               = "ipa.cal23.cyber.dhs.gov"
-  ip                     = "10.99.48.4"
-  load_balancer_hostname = "ipa.cal23.cyber.dhs.gov"
-  nessus_hostname_key    = "/cdm/nessus_hostname"
-  nessus_key_key         = "/cdm/nessus_key"
-  nessus_port_key        = "/cdm/nessus_port"
-  netbios_name           = "CAL23"
-  realm                  = "CAL23.CYBER.DHS.GOV"
-  subnet_id              = aws_subnet.subnet.id
+  ami_owner_account_id = "207871073513" # The COOL Images account
+  domain               = "cal23.cyber.dhs.gov"
+  fqdn                 = "ipa.cal23.cyber.dhs.gov"
+  ip                   = "10.99.48.4"
+  load_balancer_fqdn   = "ipa.cal23.cyber.dhs.gov"
+  nessus_hostname_key  = "/cdm/nessus_hostname"
+  nessus_key_key       = "/cdm/nessus_key"
+  nessus_port_key      = "/cdm/nessus_port"
+  netbios_name         = "CAL23"
+  realm                = "CAL23.CYBER.DHS.GOV"
+  subnet_id            = aws_subnet.subnet.id
 }

--- a/examples/basic_usage/main.tf
+++ b/examples/basic_usage/main.tf
@@ -67,14 +67,15 @@ module "ipa" {
     aws.provision_ssm_parameter_read_role = aws.provision_ssm_parameter_read_role
   }
 
-  ami_owner_account_id = "207871073513" # The COOL Images account
-  domain               = "cal23.cyber.dhs.gov"
-  hostname             = "ipa.cal23.cyber.dhs.gov"
-  ip                   = "10.99.48.4"
-  nessus_hostname_key  = "/cdm/nessus_hostname"
-  nessus_key_key       = "/cdm/nessus_key"
-  nessus_port_key      = "/cdm/nessus_port"
-  netbios_name         = "CAL23"
-  realm                = "CAL23.CYBER.DHS.GOV"
-  subnet_id            = aws_subnet.subnet.id
+  ami_owner_account_id   = "207871073513" # The COOL Images account
+  domain                 = "cal23.cyber.dhs.gov"
+  hostname               = "ipa.cal23.cyber.dhs.gov"
+  ip                     = "10.99.48.4"
+  load_balancer_hostname = "ipa.cal23.cyber.dhs.gov"
+  nessus_hostname_key    = "/cdm/nessus_hostname"
+  nessus_key_key         = "/cdm/nessus_key"
+  nessus_port_key        = "/cdm/nessus_port"
+  netbios_name           = "CAL23"
+  realm                  = "CAL23.CYBER.DHS.GOV"
+  subnet_id              = aws_subnet.subnet.id
 }

--- a/instance_role.tf
+++ b/instance_role.tf
@@ -10,7 +10,7 @@ module "read_ssm_parameters" {
   # Allow the account where the instance is being created to assume
   # this role, which lives in the Images account.
   account_ids = [data.aws_caller_identity.main.account_id]
-  entity_name = var.hostname
+  entity_name = var.fqdn
   ssm_names = [
     var.nessus_hostname_key,
     var.nessus_key_key,

--- a/variables.tf
+++ b/variables.tf
@@ -19,6 +19,11 @@ variable "ip" {
   description = "The IP address to assign the IPA server (e.g. 10.10.10.4).  Note that the IP address must be contained inside the CIDR block corresponding to subnet-id, and AWS reserves the first four and very last IP addresses.  We have to assign an IP in order to break the dependency of DNS record resources on the corresponding EC2 resources; otherwise, it is impossible to update the IPA servers one by one as is required when a new AMI is created."
 }
 
+variable "load_balancer_hostname" {
+  type        = string
+  description = "The hostname of the AWS load balancer in front of the FreeIPA cluster (e.g. ipa.example.com)."
+}
+
 variable "nessus_hostname_key" {
   type        = string
   description = "The SSM Parameter Store key whose corresponding value contains the hostname of the CDM Tenable Nessus server to which the Nessus Agent should link (e.g. /cdm/nessus/hostname)."

--- a/variables.tf
+++ b/variables.tf
@@ -11,7 +11,7 @@ variable "domain" {
 
 variable "hostname" {
   type        = string
-  description = "The hostname of the IPA server (e.g. ipa.example.com)."
+  description = "The hostname of the IPA server (e.g. ipa0.example.com)."
 }
 
 variable "ip" {

--- a/variables.tf
+++ b/variables.tf
@@ -9,9 +9,9 @@ variable "domain" {
   description = "The domain for the IPA server (e.g. example.com)."
 }
 
-variable "hostname" {
+variable "fqdn" {
   type        = string
-  description = "The hostname of the IPA server (e.g. ipa0.example.com)."
+  description = "The FQDN of the IPA server (e.g. ipa0.example.com)."
 }
 
 variable "ip" {
@@ -19,9 +19,9 @@ variable "ip" {
   description = "The IP address to assign the IPA server (e.g. 10.10.10.4).  Note that the IP address must be contained inside the CIDR block corresponding to subnet-id, and AWS reserves the first four and very last IP addresses.  We have to assign an IP in order to break the dependency of DNS record resources on the corresponding EC2 resources; otherwise, it is impossible to update the IPA servers one by one as is required when a new AMI is created."
 }
 
-variable "load_balancer_hostname" {
+variable "load_balancer_fqdn" {
   type        = string
-  description = "The hostname of the AWS load balancer in front of the FreeIPA cluster (e.g. ipa.example.com)."
+  description = "The FQDN of the AWS load balancer in front of the FreeIPA cluster (e.g. ipa.example.com)."
 }
 
 variable "nessus_hostname_key" {


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds the load balancer hostname as an input variable.

See also:
- cisagov/ansible-role-freeipa-server#49
- cisagov/cool-sharedservices-freeipa#51
- cisagov/freeipa-server-packer/pull/79

## 💭 Motivation and context ##

This is necessary to enable cisagov/ansible-role-freeipa-server#49, which is in turn necessary to support cisagov/cool-sharedservices-freeipa#51.

## 🧪 Testing ##

I have deployed these changes to our staging COOL environment and verified that they function as expected.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.