### PR TITLE
Add cloud-init foo for configuring Crowdstrike Falcon sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,30 +10,34 @@ A Terraform module for deploying a FreeIPA server.
 module "ipa0" {
   source = "github.com/cisagov/freeipa-server-tf-module"
 
-  domain              = "example.com"
-  hostname            = "ipa0.example.com"
-  ip                  = "10.10.10.4"
-  nessus_hostname_key = "/thulsa/doom/nessus/hostname"
-  nessus_key_key      = "/thulsa/doom/nessus/key"
-  nessus_port_key     = "/thulsa/doom/nessus/port"
-  netbios_name        = "EXAMPLE"
-  realm               = "EXAMPLE.COM"
-  security_group_ids  = ["sg-51530134", "sg-51530245"]
-  subnet_id           = aws_subnet.first_subnet.id
+  crowdstrike_falcon_sensor_customer_id_key = "/thulsa/doom/falcon/customer_id"
+  crowdstrike_falcon_sensor_tags_key        = "/thulsa/doom/falcon/tags"
+  domain                                    = "example.com"
+  hostname                                  = "ipa0.example.com"
+  ip                                        = "10.10.10.4"
+  nessus_hostname_key                       = "/thulsa/doom/nessus/hostname"
+  nessus_key_key                            = "/thulsa/doom/nessus/key"
+  nessus_port_key                           = "/thulsa/doom/nessus/port"
+  netbios_name                              = "EXAMPLE"
+  realm                                     = "EXAMPLE.COM"
+  security_group_ids                        = ["sg-51530134", "sg-51530245"]
+  subnet_id                                 = aws_subnet.first_subnet.id
 }
 
 module "ipa1" {
   source = "github.com/cisagov/freeipa-server-tf-module"
 
-  domain              = "example.com"
-  hostname            = "ipa1.example.com"
-  ip                  = "10.10.10.5"
-  nessus_hostname_key = "/thulsa/doom/nessus/hostname"
-  nessus_key_key      = "/thulsa/doom/nessus/key"
-  nessus_port_key     = "/thulsa/doom/nessus/port"
-  netbios_name        = "EXAMPLE"
-  security_group_ids  = ["sg-51530134", "sg-51530245"]
-  subnet_id           = aws_subnet.second_subnet.id
+  crowdstrike_falcon_sensor_customer_id_key = "/thulsa/doom/falcon/customer_id"
+  crowdstrike_falcon_sensor_tags_key        = "/thulsa/doom/falcon/tags"
+  domain                                    = "example.com"
+  hostname                                  = "ipa1.example.com"
+  ip                                        = "10.10.10.5"
+  nessus_hostname_key                       = "/thulsa/doom/nessus/hostname"
+  nessus_key_key                            = "/thulsa/doom/nessus/key"
+  nessus_port_key                           = "/thulsa/doom/nessus/port"
+  netbios_name                              = "EXAMPLE"
+  security_group_ids                        = ["sg-51530134", "sg-51530245"]
+  subnet_id                                 = aws_subnet.second_subnet.id
 }
 ```
 
@@ -88,6 +92,9 @@ module "ipa1" {
 |------|-------------|------|---------|:--------:|
 | ami\_owner\_account\_id | The ID of the AWS account that owns the FreeIPA server AMI, or "self" if the AMI is owned by the same account as the provisioner. | `string` | `"self"` | no |
 | aws\_instance\_type | The AWS instance type to deploy (e.g. t3.medium).  Two gigabytes of RAM is given as a minimum requirement for FreeIPA, but I have had intermittent problems when creating t3.small replicas. | `string` | `"t3.medium"` | no |
+| crowdstrike\_falcon\_sensor\_customer\_id\_key | The SSM Parameter Store key whose corresponding value contains the customer ID for CrowdStrike Falcon (e.g. /cdm/falcon/customer\_id). | `string` | n/a | yes |
+| crowdstrike\_falcon\_sensor\_install\_path | The install path of the CrowdStrike Falcon sensor (e.g. /opt/CrowdStrike). | `string` | `"/opt/CrowdStrike"` | no |
+| crowdstrike\_falcon\_sensor\_tags\_key | The SSM Parameter Store key whose corresponding value contains a comma-delimited list of tags that are to be applied to CrowdStrike Falcon (e.g. /cdm/falcon/tags). | `string` | n/a | yes |
 | domain | The domain for the IPA server (e.g. example.com). | `string` | n/a | yes |
 | hostname | The hostname of the IPA server (e.g. ipa.example.com). | `string` | n/a | yes |
 | ip | The IP address to assign the IPA server (e.g. 10.10.10.4).  Note that the IP address must be contained inside the CIDR block corresponding to subnet-id, and AWS reserves the first four and very last IP addresses.  We have to assign an IP in order to break the dependency of DNS record resources on the corresponding EC2 resources; otherwise, it is impossible to update the IPA servers one by one as is required when a new AMI is created. | `string` | n/a | yes |

--- a/cloud-init/configure-falcon-sensor.py
+++ b/cloud-init/configure-falcon-sensor.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+
+"""Set the customer ID for the CrowdStrike Falcon sensor.
+
+This file is a template.  It must be processed by Terraform.
+"""
+
+from __future__ import annotations
+
+# Standard Python Libraries
+# Bandit triggers B404 here, but we're only using subprocess.run() and
+# doing so safely.  For more details on B404 see here:
+# https://bandit.readthedocs.io/en/latest/blacklists/blacklist_imports.html#b404-import-subprocess
+import subprocess  # nosec
+import sys
+from typing import Any
+
+# Third-Party Libraries
+import boto3
+
+# Inputs from Terraform
+FALCON_CUSTOMER_ID_KEY: str = "${falcon_customer_id_key}"
+FALCON_SENSOR_INSTALL_PATH: str = "${falcon_sensor_install_path}"
+FALCON_TAGS_KEY: str = "${falcon_tags_key}"
+SSM_READ_ROLE_ARN: str = "${ssm_read_role_arn}"
+SSM_REGION: str = "${ssm_region}"
+
+
+def get_parameter(ssm_client, parameter_name: str, with_decryption: bool = True) -> str:
+    """Get the value of the specified parameter."""
+    response: dict[str, Any] = ssm_client.get_parameter(
+        Name=parameter_name,
+        WithDecryption=with_decryption,
+    )
+    return response["Parameter"]["Value"]
+
+
+def main() -> int:
+    """Retrieve necessary values from SSM Parameter Store and set the customer ID."""
+    # Create STS client
+    sts_client = boto3.client("sts")
+
+    # Assume the role that can read the SSM Parameter Store parameters
+    stsresponse: dict[str, Any] = sts_client.assume_role(
+        RoleArn=SSM_READ_ROLE_ARN,
+        RoleSessionName="set_crowdstrike_falcon_sensor_customer_id",
+    )
+    newsession_id = stsresponse["Credentials"]["AccessKeyId"]
+    newsession_key = stsresponse["Credentials"]["SecretAccessKey"]
+    newsession_token = stsresponse["Credentials"]["SessionToken"]
+
+    # Create a new client to access SSM Parameter Store using the
+    # temporary credentials
+    ssm_client = boto3.client(
+        "ssm",
+        aws_access_key_id=newsession_id,
+        aws_secret_access_key=newsession_key,
+        aws_session_token=newsession_token,
+        region_name=SSM_REGION,
+    )
+
+    # Get the values of the SSM Parameter Store parameters
+    customer_id: str = get_parameter(ssm_client, FALCON_CUSTOMER_ID_KEY)
+    tags: str = get_parameter(ssm_client, FALCON_TAGS_KEY)
+
+    #
+    # Set the customer ID
+    #
+    customer_id_cmd: list[str] = [
+        f"{FALCON_SENSOR_INSTALL_PATH}/falconctl",
+        # This switch denotes that we are setting (as opposed to
+        # getting the value of) a variable.  There is no long form for
+        # this switch.
+        "-s",
+        f"--cid={customer_id}",
+    ]
+    # Bandit triggers B603 here, but we're using subprocess.run()
+    # safely since the variable content in customer_id_cmd comes
+    # directly from SSM Parameter Store.  For more details on B603 see
+    # here:
+    # https://bandit.readthedocs.io/en/latest/plugins/b603_subprocess_without_shell_equals_true.html
+    cid_cp: subprocess.CompletedProcess = subprocess.run(customer_id_cmd)  # nosec
+    if cid_cp.returncode != 0:
+        return cid_cp.returncode
+
+    #
+    # Set the tags
+    #
+    tags_cmd: list[str] = [
+        f"{FALCON_SENSOR_INSTALL_PATH}/falconctl",
+        # This switch denotes that we are setting (as opposed to
+        # getting the value of) a variable.  There is no long form for
+        # this switch.
+        "-s",
+        f"--tags={tags}",
+    ]
+    # Bandit triggers B603 here, but we're using subprocess.run()
+    # safely since the variable content in tags_cmd comes
+    # directly from SSM Parameter Store.  For more details on B603 see
+    # here:
+    # https://bandit.readthedocs.io/en/latest/plugins/b603_subprocess_without_shell_equals_true.html
+    tags_cp: subprocess.CompletedProcess = subprocess.run(tags_cmd)  # nosec
+    if tags_cp.returncode != 0:
+        return tags_cp.returncode
+
+    #
+    # Restart the Falcon sensor
+    #
+    # This is necessary since the service doesn't start up
+    # successfully without a valid customer ID.
+    #
+    restart_cmd: list[str] = [
+        "/usr/bin/systemctl",
+        "restart",
+        "falcon-sensor.service",
+    ]
+    # Bandit triggers B603 here, but we're using subprocess.run()
+    # safely since the content of restart_cmd is entirely hard-coded.
+    # For more details on B603 see here:
+    # https://bandit.readthedocs.io/en/latest/plugins/b603_subprocess_without_shell_equals_true.html
+    restart_cp: subprocess.CompletedProcess = subprocess.run(restart_cmd)  # nosec
+    return restart_cp.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/cloud-init/configure-falcon-sensor.py
+++ b/cloud-init/configure-falcon-sensor.py
@@ -45,9 +45,9 @@ def main() -> int:
         RoleArn=SSM_READ_ROLE_ARN,
         RoleSessionName="set_crowdstrike_falcon_sensor_customer_id",
     )
-    newsession_id = stsresponse["Credentials"]["AccessKeyId"]
-    newsession_key = stsresponse["Credentials"]["SecretAccessKey"]
-    newsession_token = stsresponse["Credentials"]["SessionToken"]
+    newsession_id: str = stsresponse["Credentials"]["AccessKeyId"]
+    newsession_key: str = stsresponse["Credentials"]["SecretAccessKey"]
+    newsession_token: str = stsresponse["Credentials"]["SessionToken"]
 
     # Create a new client to access SSM Parameter Store using the
     # temporary credentials

--- a/examples/basic_usage/main.tf
+++ b/examples/basic_usage/main.tf
@@ -67,14 +67,16 @@ module "ipa" {
     aws.provision_ssm_parameter_read_role = aws.provision_ssm_parameter_read_role
   }
 
-  ami_owner_account_id = "207871073513" # The COOL Images account
-  domain               = "cal23.cyber.dhs.gov"
-  hostname             = "ipa.cal23.cyber.dhs.gov"
-  ip                   = "10.99.48.4"
-  nessus_hostname_key  = "/cdm/nessus_hostname"
-  nessus_key_key       = "/cdm/nessus_key"
-  nessus_port_key      = "/cdm/nessus_port"
-  netbios_name         = "CAL23"
-  realm                = "CAL23.CYBER.DHS.GOV"
-  subnet_id            = aws_subnet.subnet.id
+  ami_owner_account_id                      = "207871073513" # The COOL Images account
+  crowdstrike_falcon_sensor_customer_id_key = "/cdm/falcon/customer_id"
+  crowdstrike_falcon_sensor_tags_key        = "/cdm/falcon/tags"
+  domain                                    = "cal23.cyber.dhs.gov"
+  hostname                                  = "ipa.cal23.cyber.dhs.gov"
+  ip                                        = "10.99.48.4"
+  nessus_hostname_key                       = "/cdm/nessus_hostname"
+  nessus_key_key                            = "/cdm/nessus_key"
+  nessus_port_key                           = "/cdm/nessus_port"
+  netbios_name                              = "CAL23"
+  realm                                     = "CAL23.CYBER.DHS.GOV"
+  subnet_id                                 = aws_subnet.subnet.id
 }

--- a/instance_role.tf
+++ b/instance_role.tf
@@ -12,6 +12,8 @@ module "read_ssm_parameters" {
   account_ids = [data.aws_caller_identity.main.account_id]
   entity_name = var.hostname
   ssm_names = [
+    var.crowdstrike_falcon_sensor_customer_id_key,
+    var.crowdstrike_falcon_sensor_tags_key,
     var.nessus_hostname_key,
     var.nessus_key_key,
     var.nessus_port_key,

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,16 @@
 # You must provide a value for each of these parameters.
 # ------------------------------------------------------------------------------
 
+variable "crowdstrike_falcon_sensor_customer_id_key" {
+  type        = string
+  description = "The SSM Parameter Store key whose corresponding value contains the customer ID for CrowdStrike Falcon (e.g. /cdm/falcon/customer_id)."
+}
+
+variable "crowdstrike_falcon_sensor_tags_key" {
+  type        = string
+  description = "The SSM Parameter Store key whose corresponding value contains a comma-delimited list of tags that are to be applied to CrowdStrike Falcon (e.g. /cdm/falcon/tags)."
+}
+
 variable "domain" {
   type        = string
   description = "The domain for the IPA server (e.g. example.com)."
@@ -65,6 +75,12 @@ variable "aws_instance_type" {
   type        = string
   description = "The AWS instance type to deploy (e.g. t3.medium).  Two gigabytes of RAM is given as a minimum requirement for FreeIPA, but I have had intermittent problems when creating t3.small replicas."
   default     = "t3.medium"
+}
+
+variable "crowdstrike_falcon_sensor_install_path" {
+  type        = string
+  description = "The install path of the CrowdStrike Falcon sensor (e.g. /opt/CrowdStrike)."
+  default     = "/opt/CrowdStrike"
 }
 
 variable "nessus_agent_install_path" {


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds some cloud-init foo for configuring the Crowdstrike Falcon sensor.

## 💭 Motivation and context ##

The Crowdstrike Falcon sensor will not function as expected unless properly configured.

## 🧪 Testing ##

All automated tests pass.  I deployed a staging AMI with these changes and verified that it configured the Crowdstrike Falcon sensor as expected.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.