### PR TITLE
Upgrade the default instance type

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ module "ipa1" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | ami\_owner\_account\_id | The ID of the AWS account that owns the FreeIPA server AMI, or "self" if the AMI is owned by the same account as the provisioner. | `string` | `"self"` | no |
-| aws\_instance\_type | The AWS instance type to deploy (e.g. t3.medium).  Two gigabytes of RAM is given as a minimum requirement for FreeIPA, but I have had intermittent problems when creating t3.small replicas. | `string` | `"t3.medium"` | no |
+| aws\_instance\_type | The AWS instance type to deploy (e.g. t3.medium).  Two gigabytes of RAM is given as a minimum requirement for FreeIPA, but I have had intermittent problems when creating even t3.medium replicas using a Fedora 41 AMI. | `string` | `"t3.large"` | no |
 | crowdstrike\_falcon\_sensor\_customer\_id\_key | The SSM Parameter Store key whose corresponding value contains the customer ID for CrowdStrike Falcon (e.g. /cdm/falcon/customer\_id). | `string` | n/a | yes |
 | crowdstrike\_falcon\_sensor\_install\_path | The install path of the CrowdStrike Falcon sensor (e.g. /opt/CrowdStrike). | `string` | `"/opt/CrowdStrike"` | no |
 | crowdstrike\_falcon\_sensor\_tags\_key | The SSM Parameter Store key whose corresponding value contains a comma-delimited list of tags that are to be applied to CrowdStrike Falcon (e.g. /cdm/falcon/tags). | `string` | n/a | yes |

--- a/variables.tf
+++ b/variables.tf
@@ -83,8 +83,8 @@ variable "ami_owner_account_id" {
 }
 
 variable "aws_instance_type" {
-  default     = "t3.medium"
-  description = "The AWS instance type to deploy (e.g. t3.medium).  Two gigabytes of RAM is given as a minimum requirement for FreeIPA, but I have had intermittent problems when creating t3.small replicas."
+  default     = "t3.large"
+  description = "The AWS instance type to deploy (e.g. t3.medium).  Two gigabytes of RAM is given as a minimum requirement for FreeIPA, but I have had intermittent problems when creating even t3.medium replicas using a Fedora 41 AMI."
   nullable    = false
   type        = string
 }


### PR DESCRIPTION
## 🗣 Description ##

This pull request bumps up the default instance type from `t3.medium` to `t3.large`.

See also cisagov/freeipa-server-packer#129.

## 💭 Motivation and context ##

I recently had difficulties with `t3.medium` instances run from a Fedora 41 AMI.  (The instance was unresponsive and the CloudWatch Agent failed to start up properly.)  Bumping up the instance type made the difficulties go away.

## 🧪 Testing ##

I successfully deployed these changes as part of the testing of cisagov/freeipa-server-packer#129.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.